### PR TITLE
Release 0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This library takes the following firebase parameters:
 | `unsafe_kafka_connection` | boolean | `false` | Whether to accept unsafe HTTPS certificates. Only meant to be set to `true` in development environments. |
 | `device_services_to_connect` | string | `<empty>` | A space-separated list of device service providers to connect. The `org.radarcns` prefix may be excluded. |
 | `kafka_records_send_limit` | int | 1000 | Number of records to send in a single request. |
+| `kafka_records_size_limit` | int (bytes) | 5000000 (= 5 MB)| Maximum size to read for a single request. |
 | `kafka_upload_rate` | int (s) | 50 | Rate after which to send data. In addition, after every `kafka_upload_rate` divided by 5 seconds, if more than `kafka_records_send_limit` are in the buffer, these are sent immediately. |
 | `database_commit_rate` | int (ms) | 10000 (= 10 seconds) | Rate of committing new data to disk. If the application crashes, at most this interval of data will be lost. |
 | `sender_connection_timeout` | int (s) | 120 | HTTP timeout setting for data uploading. |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ repositories {
     jcenter()
 }
 dependencies {
-    api 'org.radarcns:radar-commons-android:0.8.0'
+    api 'org.radarcns:radar-commons-android:0.8.2'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
 // Configuration                                                             //
 //---------------------------------------------------------------------------//
 
-    version = '0.8.1-SNAPSHOT'
+    version = '0.8.2'
     ext.versionCode = 21
     group = 'org.radarcns'
     ext.githubRepoName = 'RADAR-base/radar-commons-android'

--- a/radar-commons-android/build.gradle
+++ b/radar-commons-android/build.gradle
@@ -56,7 +56,7 @@ ext.moduleName = 'radar-commons-android'
 ext.description = 'Kafka backend for processing device data.'
 
 dependencies {
-    api ('org.radarcns:radar-commons:0.11.1') {
+    api ('org.radarcns:radar-commons:0.11.2') {
         exclude group: 'org.json', module: 'json'
     }
     api 'org.radarcns:radar-schemas-commons:0.4.1'

--- a/radar-commons-android/src/main/java/org/radarcns/android/RadarConfiguration.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/RadarConfiguration.java
@@ -75,6 +75,7 @@ public class RadarConfiguration {
     public static final String DATABASE_COMMIT_RATE_KEY = "database_commit_rate";
     public static final String KAFKA_CLEAN_RATE_KEY = "kafka_clean_rate";
     public static final String KAFKA_RECORDS_SEND_LIMIT_KEY = "kafka_records_send_limit";
+    public static final String KAFKA_RECORDS_SIZE_LIMIT_KEY = "kafka_records_size_limit";
     public static final String SENDER_CONNECTION_TIMEOUT_KEY = "sender_connection_timeout";
     public static final String DATA_RETENTION_KEY = "data_retention_ms";
     public static final String FIREBASE_FETCH_TIMEOUT_MS_KEY = "firebase_fetch_timeout_ms";

--- a/radar-commons-android/src/main/java/org/radarcns/android/RadarService.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/RadarService.java
@@ -83,6 +83,7 @@ import static android.Manifest.permission.PACKAGE_USAGE_STATS;
 import static org.radarcns.android.RadarConfiguration.DATABASE_COMMIT_RATE_KEY;
 import static org.radarcns.android.RadarConfiguration.DATA_RETENTION_KEY;
 import static org.radarcns.android.RadarConfiguration.KAFKA_RECORDS_SEND_LIMIT_KEY;
+import static org.radarcns.android.RadarConfiguration.KAFKA_RECORDS_SIZE_LIMIT_KEY;
 import static org.radarcns.android.RadarConfiguration.KAFKA_REST_PROXY_URL_KEY;
 import static org.radarcns.android.RadarConfiguration.KAFKA_UPLOAD_MINIMUM_BATTERY_LEVEL;
 import static org.radarcns.android.RadarConfiguration.KAFKA_UPLOAD_RATE_KEY;
@@ -478,6 +479,11 @@ public class RadarService extends Service implements ServerStatusListener {
             localDataHandler.setKafkaRecordsSendLimit(
                     configuration.getInt(KAFKA_RECORDS_SEND_LIMIT_KEY));
         }
+        if (configuration.has(KAFKA_RECORDS_SIZE_LIMIT_KEY)) {
+            localDataHandler.setKafkaRecordsSizeLimit(
+                    configuration.getInt(KAFKA_RECORDS_SIZE_LIMIT_KEY));
+        }
+
         if (configuration.has(SENDER_CONNECTION_TIMEOUT_KEY)) {
             localDataHandler.setSenderConnectionTimeout(
                     configuration.getLong(SENDER_CONNECTION_TIMEOUT_KEY));

--- a/radar-commons-android/src/main/java/org/radarcns/android/data/ReadableDataCache.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/data/ReadableDataCache.java
@@ -28,8 +28,10 @@ import java.io.IOException;
 
 public interface ReadableDataCache extends Closeable {
     /**
-     * Get all unsent records in the cache.
+     * Get unsent records from the cache.
      *
+     * @param limit maximum number of records.
+     * @param sizeLimit maximum serialized size of those records.
      * @return records or null if none are found.
      */
     @Nullable

--- a/radar-commons-android/src/main/java/org/radarcns/android/data/ReadableDataCache.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/data/ReadableDataCache.java
@@ -33,7 +33,7 @@ public interface ReadableDataCache extends Closeable {
      * @return records or null if none are found.
      */
     @Nullable
-    RecordData<Object, Object> unsentRecords(int limit) throws IOException;
+    RecordData<Object, Object> unsentRecords(int limit, int sizeLimit) throws IOException;
 
     /**
      * Get latest records in the cache, from new to old.

--- a/radar-commons-android/src/main/java/org/radarcns/android/data/TableDataHandler.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/data/TableDataHandler.java
@@ -147,7 +147,7 @@ public class TableDataHandler implements DataHandler<ObservationKey, SpecificRec
         this.useCompression = false;
         this.authState = authState;
         this.specificData = CacheStore.get().getSpecificData();
-        this.kafkaRecordsSizeLimit = KafkaDataSubmitter.DEFAULT_SIZE_LIMIT;
+        this.kafkaRecordsSizeLimit = KafkaDataSubmitter.SIZE_LIMIT_DEFAULT;
 
         dataRetention = new AtomicLong(DATA_RETENTION_DEFAULT);
 

--- a/radar-commons-android/src/main/java/org/radarcns/android/data/TableDataHandler.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/data/TableDataHandler.java
@@ -100,6 +100,7 @@ public class TableDataHandler implements DataHandler<ObservationKey, SpecificRec
     private RestSender sender;
     private final AtomicFloat minimumBatteryLevel;
     private boolean useCompression;
+    private int kafkaRecordsSizeLimit;
 
     /**
      * Create a data handler. If kafkaConfig is null, data will only be stored to disk, not uploaded.
@@ -146,6 +147,7 @@ public class TableDataHandler implements DataHandler<ObservationKey, SpecificRec
         this.useCompression = false;
         this.authState = authState;
         this.specificData = CacheStore.get().getSpecificData();
+        this.kafkaRecordsSizeLimit = KafkaDataSubmitter.DEFAULT_SIZE_LIMIT;
 
         dataRetention = new AtomicLong(DATA_RETENTION_DEFAULT);
 
@@ -206,6 +208,7 @@ public class TableDataHandler implements DataHandler<ObservationKey, SpecificRec
                 .build();
         this.submitter = new KafkaDataSubmitter(this, sender, kafkaRecordsSendLimit,
                 getPreferredUploadRate(), authState.getUserId());
+        this.submitter.setSizeLimit(kafkaRecordsSizeLimit);
     }
 
     private synchronized boolean isStarted() {
@@ -404,6 +407,13 @@ public class TableDataHandler implements DataHandler<ObservationKey, SpecificRec
         for (DataCacheGroup<?, ?> table : tables.values()) {
             table.getActiveDataCache().setTimeWindow(period);
         }
+    }
+
+    public synchronized void setKafkaRecordsSizeLimit(int kafkaRecordsSizeLimit) {
+        if (submitter != null) {
+            submitter.setSizeLimit(kafkaRecordsSizeLimit);
+        }
+        this.kafkaRecordsSizeLimit = kafkaRecordsSizeLimit;
     }
 
     public synchronized void setKafkaRecordsSendLimit(int kafkaRecordsSendLimit) {

--- a/radar-commons-android/src/main/java/org/radarcns/android/data/TapeCache.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/data/TapeCache.java
@@ -41,6 +41,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.radarcns.android.kafka.KafkaDataSubmitter.DEFAULT_SIZE_LIMIT;
+
 /**
  * Caches measurement on a BackedObjectQueue. Internally, all data is first cached on a local queue,
  * before being written in batches to the BackedObjectQueue, using a single-threaded
@@ -107,12 +109,13 @@ public class TapeCache<K, V> implements DataCache<K, V> {
     }
 
     @Override
-    public RecordData<Object, Object> unsentRecords(final int limit) throws IOException {
+    public RecordData<Object, Object> unsentRecords(final int limit, final int sizeLimit)
+            throws IOException {
         logger.debug("Trying to retrieve records from topic {}", topic);
         try {
             return executor.submit(() -> {
                 try {
-                    List<Record<Object, Object>> records = queue.peek(limit);
+                    List<Record<Object, Object>> records = queue.peek(limit, sizeLimit);
                     if (records.isEmpty()) {
                         return null;
                     }
@@ -147,7 +150,7 @@ public class TapeCache<K, V> implements DataCache<K, V> {
 
     @Override
     public RecordData<Object, Object> getRecords(int limit) throws IOException {
-        return unsentRecords(limit);
+        return unsentRecords(limit, DEFAULT_SIZE_LIMIT);
     }
 
     @Override

--- a/radar-commons-android/src/main/java/org/radarcns/android/data/TapeCache.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/data/TapeCache.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.radarcns.android.kafka.KafkaDataSubmitter.DEFAULT_SIZE_LIMIT;
+import static org.radarcns.android.kafka.KafkaDataSubmitter.SIZE_LIMIT_DEFAULT;
 
 /**
  * Caches measurement on a BackedObjectQueue. Internally, all data is first cached on a local queue,
@@ -150,7 +150,7 @@ public class TapeCache<K, V> implements DataCache<K, V> {
 
     @Override
     public RecordData<Object, Object> getRecords(int limit) throws IOException {
-        return unsentRecords(limit, DEFAULT_SIZE_LIMIT);
+        return unsentRecords(limit, SIZE_LIMIT_DEFAULT);
     }
 
     @Override

--- a/radar-commons-android/src/main/java/org/radarcns/android/kafka/KafkaDataSubmitter.java
+++ b/radar-commons-android/src/main/java/org/radarcns/android/kafka/KafkaDataSubmitter.java
@@ -52,7 +52,7 @@ import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
  */
 public class KafkaDataSubmitter implements Closeable {
     private static final Logger logger = LoggerFactory.getLogger(KafkaDataSubmitter.class);
-    public static final int DEFAULT_SIZE_LIMIT = 5_000_000;  // 5 MB
+    public static final int SIZE_LIMIT_DEFAULT = 5_000_000;  // 5 MB
 
     private final DataHandler<?, ?> dataHandler;
     private final KafkaSender sender;
@@ -76,7 +76,7 @@ public class KafkaDataSubmitter implements Closeable {
         this.userId = userId;
         topicSenders = new HashMap<>();
         this.sendLimit = new AtomicInteger(sendLimit);
-        this.sizeLimit = new AtomicInteger(DEFAULT_SIZE_LIMIT);
+        this.sizeLimit = new AtomicInteger(SIZE_LIMIT_DEFAULT);
 
         mHandlerThread = new HandlerThread("data-submitter", THREAD_PRIORITY_BACKGROUND);
         mHandlerThread.start();

--- a/radar-commons-android/src/main/java/org/radarcns/util/BackedObjectQueue.java
+++ b/radar-commons-android/src/main/java/org/radarcns/util/BackedObjectQueue.java
@@ -110,11 +110,16 @@ public class BackedObjectQueue<S, T> implements Closeable {
      * @throws IOException if the element could not be read or deserialized
      * @throws IllegalStateException if the element could not be read
      */
-    public List<T> peek(int n) throws IOException {
+    public List<T> peek(int n, int sizeLimit) throws IOException {
         Iterator<InputStream> iter = queueFile.iterator();
+        int curSize = 0;
         List<T> results = new ArrayList<>(n);
         for (int i = 0; i < n && iter.hasNext(); i++) {
             try (InputStream in = iter.next()) {
+                curSize += in.available();
+                if (curSize >= sizeLimit) {
+                    break;
+                }
                 try {
                     results.add(deserializer.deserialize(in));
                 } catch (IllegalStateException ex) {

--- a/radar-commons-android/src/main/java/org/radarcns/util/BackedObjectQueue.java
+++ b/radar-commons-android/src/main/java/org/radarcns/util/BackedObjectQueue.java
@@ -104,8 +104,11 @@ public class BackedObjectQueue<S, T> implements Closeable {
 
     /**
      * Get at most {@code n} front-most objects in the queue. This does not remove the elements.
-     * Elements that were found to be invalid according to the current schema are
-     * @param n number of elements to retrieve
+     * Elements that were found to be invalid according to the current schema are logged. This
+     * method will try to read at least one record. After that, no more than {@code n} records are
+     * read, and their collective serialized size is no larger than {@code sizeLimit}.
+     * @param n number of elements to retrieve at most.
+     * @param sizeLimit limit for the size of read data.
      * @return list of elements, with at most {@code n} elements.
      * @throws IOException if the element could not be read or deserialized
      * @throws IllegalStateException if the element could not be read

--- a/radar-commons-android/src/main/java/org/radarcns/util/BackedObjectQueue.java
+++ b/radar-commons-android/src/main/java/org/radarcns/util/BackedObjectQueue.java
@@ -120,7 +120,7 @@ public class BackedObjectQueue<S, T> implements Closeable {
         for (int i = 0; i < n && iter.hasNext(); i++) {
             try (InputStream in = iter.next()) {
                 curSize += in.available();
-                if (i > 0 && curSize >= sizeLimit) {
+                if (i > 0 && curSize > sizeLimit) {
                     break;
                 }
                 try {

--- a/radar-commons-android/src/main/java/org/radarcns/util/BackedObjectQueue.java
+++ b/radar-commons-android/src/main/java/org/radarcns/util/BackedObjectQueue.java
@@ -117,7 +117,7 @@ public class BackedObjectQueue<S, T> implements Closeable {
         for (int i = 0; i < n && iter.hasNext(); i++) {
             try (InputStream in = iter.next()) {
                 curSize += in.available();
-                if (curSize >= sizeLimit) {
+                if (i > 0 && curSize >= sizeLimit) {
                     break;
                 }
                 try {


### PR DESCRIPTION
Changes since version 0.8.1:
- Set maximum message size to avoid running out of memory
- Updated to radar-commons 0.11.2 that sets a maximum error message size.