### PR TITLE
Added customization points for data and auth serialization

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -16,8 +16,8 @@ ext {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.0.1'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.7.2'
 
     // Core library
     androidTestImplementation "androidx.test:core:$androidXCoreVersion"
@@ -50,6 +50,20 @@ dependencies {
     unmock 'org.robolectric:android-all:5.0.2_r3-robolectric-r0'
 }
 
+android.testOptions.unitTests.all {
+    // Configure whether failing tests should fail the build
+    ignoreFailures false
+
+    testLogging {
+        exceptionFormat "full"
+        showCauses true
+        showExceptions true
+        showStackTraces true
+        showStandardStreams true
+        events = ["passed", "skipped", "failed", "standardOut", "standardError"]
+    }
+}
+
 unMock {
     keep "android.widget.BaseAdapter"
     keep "android.widget.ArrayAdapter"
@@ -61,6 +75,7 @@ unMock {
     keepStartingWith "android.text.TextUtils"
     keepStartingWith "android.util."
     keepStartingWith "android.text."
+    keepStartingWith "android.security.keystore."
     keep "android.app.Application"
     keep "android.content.Context"
     keep "android.app.ContextImpl"

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusManager.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusManager.kt
@@ -132,7 +132,7 @@ class ApplicationStatusManager internal constructor(service: ApplicationStatusSe
                 state.addRecordsSent(max(numberOfRecordsSent, 0))
             }
             cacheReceiver = register(CACHE_TOPIC) { _, intent ->
-                val topic = intent.getStringExtra(CACHE_TOPIC)
+                val topic = intent.getStringExtra(CACHE_TOPIC) ?: return@register
                 val records = intent.getLongExtra(CACHE_RECORDS_UNSENT_NUMBER, 0)
                 state.cachedRecords[topic] = max(records, 0)
             }

--- a/plugins/radar-android-phone-telephony/src/main/java/org/radarbase/passive/phone/telephony/PhoneLogManager.kt
+++ b/plugins/radar-android-phone-telephony/src/main/java/org/radarbase/passive/phone/telephony/PhoneLogManager.kt
@@ -43,7 +43,7 @@ class PhoneLogManager(context: PhoneLogService) : AbstractSourceManager<PhoneLog
     private val smsTopic: DataCache<ObservationKey, PhoneSms> = createCache("android_phone_sms", PhoneSms())
     private val smsUnreadTopic: DataCache<ObservationKey, PhoneSmsUnread> = createCache("android_phone_sms_unread", PhoneSmsUnread())
     private val preferences: SharedPreferences = context.getSharedPreferences(PhoneLogService::class.java.name, Context.MODE_PRIVATE)
-    private val hashGenerator: HashGenerator = HashGenerator(preferences)
+    private val hashGenerator = HashGenerator(context, PhoneLogService::class.java.name)
     private val db: ContentResolver = context.contentResolver
     private val logProcessor: OfflineProcessor
     private var lastSmsTimestamp: Long = 0

--- a/radar-commons-android/src/androidTest/java/org/radarbase/android/auth/SharedPreferencesAuthSerializationTest.kt
+++ b/radar-commons-android/src/androidTest/java/org/radarbase/android/auth/SharedPreferencesAuthSerializationTest.kt
@@ -11,7 +11,7 @@ import org.radarbase.android.auth.portal.ManagementPortalClient
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
-class SharedPreferencesAuthSerializerTest {
+class SharedPreferencesAuthSerializationTest {
     private lateinit var state: AppAuthState
     private lateinit var sources: List<SourceMetadata>
 
@@ -40,7 +40,7 @@ class SharedPreferencesAuthSerializerTest {
     @Test
     fun addToPreferences() {
         val readState = ApplicationProvider.getApplicationContext<Context>().let { context ->
-            val authSerializer = SharedPreferencesAuthSerializer(context)
+            val authSerializer = SharedPreferencesAuthSerialization(context)
             authSerializer.store(state)
             authSerializer.load()
         }

--- a/radar-commons-android/src/androidTest/java/org/radarbase/android/auth/SharedPreferencesAuthSerializerTest.kt
+++ b/radar-commons-android/src/androidTest/java/org/radarbase/android/auth/SharedPreferencesAuthSerializerTest.kt
@@ -3,16 +3,16 @@ package org.radarbase.android.auth
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Assert.*
+import org.junit.Assert
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.radarbase.android.auth.LoginManager.Companion.AUTH_TYPE_BEARER
-import org.radarbase.android.auth.portal.ManagementPortalClient.Companion.MP_REFRESH_TOKEN_PROPERTY
+import org.radarbase.android.auth.portal.ManagementPortalClient
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
-class AppAuthStateTest {
+class SharedPreferencesAuthSerializerTest {
     private lateinit var state: AppAuthState
     private lateinit var sources: List<SourceMetadata>
 
@@ -25,10 +25,10 @@ class AppAuthStateTest {
 
         state = AppAuthState {
             token = "abcd"
-            tokenType = AUTH_TYPE_BEARER
+            tokenType = LoginManager.AUTH_TYPE_BEARER
             projectId = "p"
             userId = "u"
-            attributes[MP_REFRESH_TOKEN_PROPERTY] = "efgh"
+            attributes[ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY] = "efgh"
             sourceMetadata += sources
             addHeader("Authorization", "Bearer abcd")
             expiration = System.currentTimeMillis() + 10_000L
@@ -41,32 +41,24 @@ class AppAuthStateTest {
     @Test
     fun addToPreferences() {
         val readState = ApplicationProvider.getApplicationContext<Context>().let { context ->
-            state.addToPreferences(context)
-            AppAuthState.from(context)
+            val authSerializer = SharedPreferencesAuthSerializer(context)
+            authSerializer.store(state)
+            authSerializer.load()
         }
 
-        testProperties(readState)
+        assertNotNull(readState)
+        testProperties(readState!!)
     }
 
     private fun testProperties(state: AppAuthState, refreshToken: String = "efgh") {
-        assertEquals("abcd", state.token)
-        assertEquals(refreshToken, state.getAttribute(MP_REFRESH_TOKEN_PROPERTY))
-        assertEquals("p", state.projectId)
-        assertEquals("u", state.userId)
-        assertTrue(state.isValidFor(9, TimeUnit.SECONDS))
-        assertFalse(state.isValidFor(11, TimeUnit.SECONDS))
-        assertEquals(AUTH_TYPE_BEARER.toLong(), state.tokenType.toLong())
-        assertEquals("Bearer abcd", state.headers[0].value)
-        assertEquals(sources, state.sourceMetadata)
-    }
-
-    @Test
-    fun newBuilder() {
-        val builtState = state.alter {
-            attributes[MP_REFRESH_TOKEN_PROPERTY] = "else"
-        }
-
-        testProperties(builtState, "else")
-        testProperties(state)
+        Assert.assertEquals("abcd", state.token)
+        Assert.assertEquals(refreshToken, state.getAttribute(ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY))
+        Assert.assertEquals("p", state.projectId)
+        Assert.assertEquals("u", state.userId)
+        Assert.assertTrue(state.isValidFor(9, TimeUnit.SECONDS))
+        Assert.assertFalse(state.isValidFor(11, TimeUnit.SECONDS))
+        Assert.assertEquals(LoginManager.AUTH_TYPE_BEARER.toLong(), state.tokenType.toLong())
+        Assert.assertEquals("Bearer abcd", state.headers[0].value)
+        Assert.assertEquals(sources, state.sourceMetadata)
     }
 }

--- a/radar-commons-android/src/androidTest/java/org/radarbase/android/auth/SharedPreferencesAuthSerializerTest.kt
+++ b/radar-commons-android/src/androidTest/java/org/radarbase/android/auth/SharedPreferencesAuthSerializerTest.kt
@@ -3,8 +3,7 @@ package org.radarbase.android.auth
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Assert
-import org.junit.Assert.assertNotNull
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,14 +50,14 @@ class SharedPreferencesAuthSerializerTest {
     }
 
     private fun testProperties(state: AppAuthState, refreshToken: String = "efgh") {
-        Assert.assertEquals("abcd", state.token)
-        Assert.assertEquals(refreshToken, state.getAttribute(ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY))
-        Assert.assertEquals("p", state.projectId)
-        Assert.assertEquals("u", state.userId)
-        Assert.assertTrue(state.isValidFor(9, TimeUnit.SECONDS))
-        Assert.assertFalse(state.isValidFor(11, TimeUnit.SECONDS))
-        Assert.assertEquals(LoginManager.AUTH_TYPE_BEARER.toLong(), state.tokenType.toLong())
-        Assert.assertEquals("Bearer abcd", state.headers[0].value)
-        Assert.assertEquals(sources, state.sourceMetadata)
+        assertEquals("abcd", state.token)
+        assertEquals(refreshToken, state.getAttribute(ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY))
+        assertEquals("p", state.projectId)
+        assertEquals("u", state.userId)
+        assertTrue(state.isValidFor(9, TimeUnit.SECONDS))
+        assertFalse(state.isValidFor(11, TimeUnit.SECONDS))
+        assertEquals(LoginManager.AUTH_TYPE_BEARER.toLong(), state.tokenType.toLong())
+        assertEquals("Bearer abcd", state.headers[0].value)
+        assertEquals(sources, state.sourceMetadata)
     }
 }

--- a/radar-commons-android/src/androidTest/java/org/radarbase/android/data/TapeCacheTest.kt
+++ b/radar-commons-android/src/androidTest/java/org/radarbase/android/data/TapeCacheTest.kt
@@ -29,6 +29,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
+import org.radarbase.android.data.serialization.TapeAvroSerializationFactory
 import org.radarbase.android.kafka.KafkaDataSubmitter.Companion.SIZE_LIMIT_DEFAULT
 import org.radarbase.android.util.SafeHandler
 import org.radarbase.topic.AvroTopic
@@ -46,8 +47,7 @@ class TapeCacheTest {
     private lateinit var tapeCache: TapeCache<ObservationKey, ApplicationUptime>
     private lateinit var key: ObservationKey
     private lateinit var value: ApplicationUptime
-    private val specificData = CacheStore.specificData
-    private val genericData = CacheStore.genericData
+    private val serializationFactory = TapeAvroSerializationFactory()
 
     @Rule @JvmField
     var folder = TemporaryFolder()
@@ -63,7 +63,7 @@ class TapeCacheTest {
                     Any::class.java, Any::class.java)
 
             return TapeCache(
-                    folder.newFile(), topic, outputTopic, handler, specificData, genericData,
+                    folder.newFile(), topic, outputTopic, handler, serializationFactory,
                     DataCache.CacheConfiguration(100L))
         }
 
@@ -83,7 +83,7 @@ class TapeCacheTest {
             start()
         }
         tapeCache = TapeCache(folder.newFile(), topic,
-                outputTopic, handler, specificData, genericData,
+                outputTopic, handler, serializationFactory,
                 DataCache.CacheConfiguration(100, 4096))
 
         key = ObservationKey("test", "a", "b")

--- a/radar-commons-android/src/androidTest/java/org/radarbase/android/util/HashGeneratorTest.java
+++ b/radar-commons-android/src/androidTest/java/org/radarbase/android/util/HashGeneratorTest.java
@@ -19,7 +19,6 @@ package org.radarbase.android.util;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +28,12 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Test that all hashes are unique for different values and the same for the same values.
@@ -60,11 +65,11 @@ public class HashGeneratorTest {
             byte[] b1 = hasher1.createHash(v);
             byte[] b2 = hasher1a.createHash(v);
             byte[] b3 = hasher2.createHash(v);
-            Assert.assertNotNull(b1);
-            Assert.assertArrayEquals(b2, b1);
-            Assert.assertFalse(Arrays.equals(b3, b1));
+            assertNotNull(b1);
+            assertArrayEquals(b2, b1);
+            assertFalse(Arrays.equals(b3, b1));
             if (i > 0 && previousV != v) {
-                Assert.assertFalse(Arrays.equals(previousB, b1));
+                assertFalse(Arrays.equals(previousB, b1));
             }
             previousV = v;
             previousB = b1;
@@ -80,10 +85,10 @@ public class HashGeneratorTest {
             byte[] b1 = hasher1.createHash(v);
             byte[] b2 = hasher1a.createHash(v);
             byte[] b3 = hasher2.createHash(v);
-            Assert.assertArrayEquals(b2, b1);
-            Assert.assertFalse(Arrays.equals(b3, b1));
+            assertArrayEquals(b2, b1);
+            assertFalse(Arrays.equals(b3, b1));
             if (i > 0 && !v.equals(previousV)) {
-                Assert.assertFalse(Arrays.equals(previousB, b1));
+                assertFalse(Arrays.equals(previousB, b1));
             }
             previousV = v;
             previousB = b1;
@@ -101,10 +106,10 @@ public class HashGeneratorTest {
             ByteBuffer b1 = hasher1.createHashByteBuffer(v);
             ByteBuffer b2 = hasher1a.createHashByteBuffer(v);
             ByteBuffer b3 = hasher2.createHashByteBuffer(v);
-            Assert.assertEquals(b2, b1);
-            Assert.assertNotEquals(b3, b1);
+            assertEquals(b2, b1);
+            assertNotEquals(b3, b1);
             if (i > 0 && v != previousV) {
-                Assert.assertNotEquals(previousB, b1);
+                assertNotEquals(previousB, b1);
             }
             previousV = v;
             previousB = b1;
@@ -120,10 +125,10 @@ public class HashGeneratorTest {
             ByteBuffer b1 = hasher1.createHashByteBuffer(v);
             ByteBuffer b2 = hasher1a.createHashByteBuffer(v);
             ByteBuffer b3 = hasher2.createHashByteBuffer(v);
-            Assert.assertEquals(b2, b1);
-            Assert.assertNotEquals(b3, b1);
+            assertEquals(b2, b1);
+            assertNotEquals(b3, b1);
             if (i > 0 && !v.equals(previousV)) {
-                Assert.assertNotEquals(previousB, b1);
+                assertNotEquals(previousB, b1);
             }
             previousV = v;
             previousB = b1;

--- a/radar-commons-android/src/androidTest/java/org/radarbase/android/util/HashGeneratorTest.java
+++ b/radar-commons-android/src/androidTest/java/org/radarbase/android/util/HashGeneratorTest.java
@@ -1,4 +1,4 @@
-package org.radarbase.android.util;/*
+/*
  * Copyright 2017 The Hyve
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +14,13 @@ package org.radarbase.android.util;/*
  * limitations under the License.
  */
 
-import android.content.Context;
-import android.content.SharedPreferences;
+package org.radarbase.android.util;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,9 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
-
-import androidx.test.core.app.ApplicationProvider;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Test that all hashes are unique for different values and the same for the same values.
@@ -35,15 +36,21 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
  */
 @RunWith(AndroidJUnit4.class)
 public class HashGeneratorTest {
+    private HashGenerator hasher1;
+    private HashGenerator hasher1a;
+    private HashGenerator hasher2;
 
-    private SharedPreferences getPrefs(String name) {
-        return ApplicationProvider.getApplicationContext().getSharedPreferences(name, Context.MODE_PRIVATE);
+    @Before
+    public void setUp() {
+        int v1 = ThreadLocalRandom.current().nextInt();
+        int v2 = ThreadLocalRandom.current().nextInt();
+        hasher1 = new HashGenerator(ApplicationProvider.getApplicationContext(), "createHash1" + v1);
+        hasher1a = new HashGenerator(ApplicationProvider.getApplicationContext(), "createHash1" + v1);
+        hasher2 = new HashGenerator(ApplicationProvider.getApplicationContext(), "createHash2" + v2);
     }
 
     @Test
     public void createHash() {
-        HashGenerator hasher1 = new HashGenerator(getPrefs("createHash1"));
-        HashGenerator hasher2 = new HashGenerator(getPrefs("createHash2"));
         Random random = new Random();
 
         byte[] previousB = null;
@@ -51,10 +58,10 @@ public class HashGeneratorTest {
         for (int i = 0; i < 10; i++) {
             int v = random.nextInt();
             byte[] b1 = hasher1.createHash(v);
-            byte[] b2 = hasher1.createHash(v);
+            byte[] b2 = hasher1a.createHash(v);
             byte[] b3 = hasher2.createHash(v);
             Assert.assertNotNull(b1);
-            Assert.assertTrue(Arrays.equals(b2, b1));
+            Assert.assertArrayEquals(b2, b1);
             Assert.assertFalse(Arrays.equals(b3, b1));
             if (i > 0 && previousV != v) {
                 Assert.assertFalse(Arrays.equals(previousB, b1));
@@ -66,17 +73,14 @@ public class HashGeneratorTest {
 
     @Test
     public void createHash1() {
-        HashGenerator hasher1 = new HashGenerator(getPrefs("createHashString1"));
-        HashGenerator hasher2 = new HashGenerator(getPrefs("createHashString2"));
-
         byte[] previousB = null;
         String previousV = null;
         for (int i = 0; i < 10; i++) {
             String v = UUID.randomUUID().toString();
             byte[] b1 = hasher1.createHash(v);
-            byte[] b2 = hasher1.createHash(v);
+            byte[] b2 = hasher1a.createHash(v);
             byte[] b3 = hasher2.createHash(v);
-            Assert.assertTrue(Arrays.equals(b2, b1));
+            Assert.assertArrayEquals(b2, b1);
             Assert.assertFalse(Arrays.equals(b3, b1));
             if (i > 0 && !v.equals(previousV)) {
                 Assert.assertFalse(Arrays.equals(previousB, b1));
@@ -88,8 +92,6 @@ public class HashGeneratorTest {
 
     @Test
     public void createHashByteBuffer() {
-        HashGenerator hasher1 = new HashGenerator(getPrefs("createHashByteBuffer1"));
-        HashGenerator hasher2 = new HashGenerator(getPrefs("createHashByteBuffer2"));
         Random random = new Random();
 
         ByteBuffer previousB = null;
@@ -97,7 +99,7 @@ public class HashGeneratorTest {
         for (int i = 0; i < 10; i++) {
             int v = random.nextInt();
             ByteBuffer b1 = hasher1.createHashByteBuffer(v);
-            ByteBuffer b2 = hasher1.createHashByteBuffer(v);
+            ByteBuffer b2 = hasher1a.createHashByteBuffer(v);
             ByteBuffer b3 = hasher2.createHashByteBuffer(v);
             Assert.assertEquals(b2, b1);
             Assert.assertNotEquals(b3, b1);
@@ -111,15 +113,12 @@ public class HashGeneratorTest {
 
     @Test
     public void createHashByteBuffer1() {
-        HashGenerator hasher1 = new HashGenerator(getPrefs("createHashByteBufferString1"));
-        HashGenerator hasher2 = new HashGenerator(getPrefs("createHashByteBufferString2"));
-
         ByteBuffer previousB = null;
         String previousV = null;
         for (int i = 0; i < 10; i++) {
             String v = UUID.randomUUID().toString();
             ByteBuffer b1 = hasher1.createHashByteBuffer(v);
-            ByteBuffer b2 = hasher1.createHashByteBuffer(v);
+            ByteBuffer b2 = hasher1a.createHashByteBuffer(v);
             ByteBuffer b3 = hasher2.createHashByteBuffer(v);
             Assert.assertEquals(b2, b1);
             Assert.assertNotEquals(b3, b1);

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/AppAuthState.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/AppAuthState.kt
@@ -213,10 +213,40 @@ class AppAuthState private constructor(builder: Builder) {
                 ", \nexpiration=" + expiration +
                 ", \nlastUpdate=" + lastUpdate +
                 ", \nattributes=" + attributes +
+                ", \nsourceTypes=" + sourceTypes +
                 ", \nsourceMetadata=" + sourceMetadata +
                 ", \nparseHeaders=" + headers +
                 ", \nisPrivacyPolicyAccepted=" + isPrivacyPolicyAccepted +
                 "\n")
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AppAuthState
+
+        if (projectId != other.projectId) return false
+        if (userId != other.userId) return false
+        if (token != other.token) return false
+        if (tokenType != other.tokenType) return false
+        if (authenticationSource != other.authenticationSource) return false
+        if (needsRegisteredSources != other.needsRegisteredSources) return false
+        if (expiration != other.expiration) return false
+        if (attributes != other.attributes) return false
+        if (headers != other.headers) return false
+        if (sourceMetadata != other.sourceMetadata) return false
+        if (sourceTypes != other.sourceTypes) return false
+        if (isPrivacyPolicyAccepted != other.isPrivacyPolicyAccepted) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = projectId?.hashCode() ?: 0
+        result = 31 * result + (userId?.hashCode() ?: 0)
+        result = 31 * result + (token?.hashCode() ?: 0)
+        return result
     }
 
     companion object {

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/AppAuthState.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/AppAuthState.kt
@@ -16,10 +16,7 @@
 
 package org.radarbase.android.auth
 
-import android.content.Context
-import android.content.SharedPreferences
 import android.os.SystemClock
-import android.util.Base64
 import androidx.annotation.Keep
 import okhttp3.Headers
 import org.json.JSONArray
@@ -28,9 +25,6 @@ import org.radarbase.android.auth.LoginManager.Companion.AUTH_TYPE_UNKNOWN
 import org.radarbase.android.auth.portal.ManagementPortalClient.Companion.SOURCES_PROPERTY
 import org.radarcns.android.auth.AppSource
 import org.slf4j.LoggerFactory
-import java.io.ByteArrayInputStream
-import java.io.IOException
-import java.io.ObjectInputStream
 import java.io.Serializable
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -46,7 +40,7 @@ class AppAuthState private constructor(builder: Builder) {
     val tokenType: Int
     val authenticationSource: String?
     val needsRegisteredSources: Boolean
-    private val expiration: Long
+    val expiration: Long
     val lastUpdate: Long
     val attributes: Map<String, String>
     val headers: List<Map.Entry<String, String>>
@@ -88,41 +82,15 @@ class AppAuthState private constructor(builder: Builder) {
 
     fun getAttribute(key: String) = attributes[key]
 
-    private fun serializableAttributeList() = serializedMap(attributes.entries)
+    fun serializableAttributeList() = serializedMap(attributes.entries)
 
-    private fun serializableHeaderList() = serializedMap(headers)
+    fun serializableHeaderList() = serializedMap(headers)
 
     fun isValidFor(time: Long, unit: TimeUnit) = isPrivacyPolicyAccepted
             && expiration - unit.toMillis(time) > System.currentTimeMillis()
 
     val timeSinceLastUpdate: Long
             get() = SystemClock.elapsedRealtime() - lastUpdate
-
-    fun addToPreferences(context: Context) {
-        val prefs = context.getSharedPreferences(AUTH_PREFS, Context.MODE_PRIVATE)
-
-        prefs.edit().apply {
-            putString(LOGIN_PROJECT_ID, projectId)
-            putString(LOGIN_USER_ID, userId)
-            putString(LOGIN_TOKEN, token)
-            putString(LOGIN_HEADERS_LIST, serializableHeaderList())
-            putString(LOGIN_ATTRIBUTES, serializableAttributeList())
-            putInt(LOGIN_TOKEN_TYPE, tokenType)
-            putLong(LOGIN_EXPIRATION, expiration)
-            putBoolean(LOGIN_PRIVACY_POLICY_ACCEPTED, isPrivacyPolicyAccepted)
-            putString(LOGIN_AUTHENTICATION_SOURCE, authenticationSource)
-            putBoolean(LOGIN_NEEDS_REGISTERD_SOURCES, needsRegisteredSources)
-            remove(LOGIN_PROPERTIES)
-            remove(LOGIN_HEADERS)
-            putStringSet(LOGIN_APP_SOURCES_LIST, HashSet<String>().apply {
-                addAll(sourceMetadata.map(SourceMetadata::toJsonString))
-            })
-            putStringSet(LOGIN_SOURCE_TYPES, HashSet<String>().apply {
-                addAll(sourceTypes.map(SourceType::toJsonString))
-            })
-            remove(SOURCES_PROPERTY)
-        }.apply()
-    }
 
     fun alter(changes: Builder.() -> Unit): AppAuthState {
         return Builder().also {
@@ -252,22 +220,6 @@ class AppAuthState private constructor(builder: Builder) {
     }
 
     companion object {
-        private const val LOGIN_PROJECT_ID = "org.radarcns.android.auth.AppAuthState.projectId"
-        private const val LOGIN_USER_ID = "org.radarcns.android.auth.AppAuthState.userId"
-        private const val LOGIN_TOKEN = "org.radarcns.android.auth.AppAuthState.token"
-        private const val LOGIN_TOKEN_TYPE = "org.radarcns.android.auth.AppAuthState.tokenType"
-        private const val LOGIN_EXPIRATION = "org.radarcns.android.auth.AppAuthState.expiration"
-        private const val AUTH_PREFS = "org.radarcns.auth"
-        private const val LOGIN_PROPERTIES = "org.radarcns.android.auth.AppAuthState.properties"
-        private const val LOGIN_ATTRIBUTES = "org.radarcns.android.auth.AppAuthState.attributes"
-        private const val LOGIN_HEADERS = "org.radarcns.android.auth.AppAuthState.parseHeaders"
-        private const val LOGIN_HEADERS_LIST = "org.radarcns.android.auth.AppAuthState.headerList"
-        private const val LOGIN_APP_SOURCES_LIST = "org.radarcns.android.auth.AppAuthState.appSourcesList"
-        private const val LOGIN_PRIVACY_POLICY_ACCEPTED = "org.radarcns.android.auth.AppAuthState.isPrivacyPolicyAccepted"
-        private const val LOGIN_AUTHENTICATION_SOURCE = "org.radarcns.android.auth.AppAuthState.authenticationSource"
-        private const val LOGIN_NEEDS_REGISTERD_SOURCES = "org.radarcns.android.auth.AppAuthState.needsRegisteredSources"
-        private const val LOGIN_SOURCE_TYPES = "org.radarcns.android.auth.AppAuthState.sourceTypes"
-
         private val logger = LoggerFactory.getLogger(AppAuthState::class.java)
 
         private fun serializedMap(map: Collection<Map.Entry<String, String>>): String {
@@ -301,79 +253,6 @@ class AppAuthState private constructor(builder: Builder) {
                 i += 2
             }
             return list
-        }
-
-        private fun readSerializable(prefs: SharedPreferences, key: String): Any? {
-            val propString = prefs.getString(key, null)
-            if (propString != null) {
-                val propBytes = Base64.decode(propString, Base64.NO_WRAP)
-                try {
-                    ByteArrayInputStream(propBytes).use { bi ->
-                        ObjectInputStream(bi).use { it.readObject() }
-                    }
-                } catch (ex: IOException) {
-                    logger.warn("Failed to deserialize object {} from preferences", key, ex)
-                } catch (ex: ClassNotFoundException) {
-                    logger.warn("Failed to deserialize object {} from preferences", key, ex)
-                }
-
-            }
-            return null
-        }
-
-        fun from(context: Context): AppAuthState {
-            val prefs = context.getSharedPreferences(AUTH_PREFS, Context.MODE_PRIVATE)
-
-            val builder = Builder()
-
-            try {
-                readSerializable(prefs, LOGIN_PROPERTIES)
-                        ?.let {
-                            @Suppress("UNCHECKED_CAST")
-                            it as HashMap<String, out Serializable>?
-                        }?.also {
-                            @Suppress("DEPRECATION")
-                            builder.properties(it)
-                        }
-            } catch (ex: Exception) {
-                logger.warn("Cannot read AppAuthState properties", ex)
-            }
-
-            try {
-                readSerializable(prefs, LOGIN_HEADERS)
-                        ?.let {
-                            @Suppress("UNCHECKED_CAST")
-                            it as ArrayList<Map.Entry<String, String>>?
-                        }
-                        ?.also { builder.headers += it }
-            } catch (ex: Exception) {
-                logger.warn("Cannot read AppAuthState parseHeaders", ex)
-            }
-
-            try {
-                prefs.getStringSet(LOGIN_APP_SOURCES_LIST, null)
-                        ?.also { builder.parseSourceMetadata(it) }
-            } catch (ex: JSONException) {
-                logger.warn("Cannot parse source metadata parseHeaders", ex)
-            }
-            try {
-                prefs.getStringSet(LOGIN_SOURCE_TYPES, null)
-                        ?.also { builder.parseSourceTypes(it) }
-            } catch (ex: JSONException) {
-                logger.warn("Cannot parse source types parseHeaders", ex)
-            }
-
-            return builder.apply {
-                projectId = prefs.getString(LOGIN_PROJECT_ID, null)
-                userId =prefs.getString(LOGIN_USER_ID, null)
-                token = prefs.getString(LOGIN_TOKEN, null)
-                tokenType = prefs.getInt(LOGIN_TOKEN_TYPE, 0)
-                expiration = prefs.getLong(LOGIN_EXPIRATION, 0L)
-                parseAttributes(prefs.getString(LOGIN_ATTRIBUTES, null))
-                parseHeaders(prefs.getString(LOGIN_HEADERS_LIST, null))
-                isPrivacyPolicyAccepted = prefs.getBoolean(LOGIN_PRIVACY_POLICY_ACCEPTED, false)
-                needsRegisteredSources = prefs.getBoolean(LOGIN_NEEDS_REGISTERD_SOURCES, true)
-            }.build()
         }
     }
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/AuthSerialization.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/AuthSerialization.kt
@@ -1,7 +1,7 @@
 package org.radarbase.android.auth
 
 /** Manages persistence of the AppAuthState. */
-interface AuthSerializer {
+interface AuthSerialization {
     /**
      * Load the state from this serialization.
      * @return state if it was stored, null otherwise.

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/AuthSerializer.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/AuthSerializer.kt
@@ -1,7 +1,18 @@
 package org.radarbase.android.auth
 
+/** Manages persistence of the AppAuthState. */
 interface AuthSerializer {
+    /**
+     * Load the state from this serialization.
+     * @return state if it was stored, null otherwise.
+     */
     fun load(): AppAuthState?
+    /**
+     * Store the auth state to this serialization.
+     */
     fun store(state: AppAuthState)
+    /**
+     * Remove the auth state from this serialization.
+     */
     fun remove()
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/AuthSerializer.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/AuthSerializer.kt
@@ -1,0 +1,7 @@
+package org.radarbase.android.auth
+
+interface AuthSerializer {
+    fun load(): AppAuthState?
+    fun store(state: AppAuthState)
+    fun remove()
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/AuthService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/AuthService.kt
@@ -33,8 +33,8 @@ abstract class AuthService : Service(), LoginListener {
     private var currentDelay: Long? = null
     private var isConnected: Boolean = false
 
-    open val authSerializers: List<AuthSerializer> by lazy {
-        listOf(SharedPreferencesAuthSerializer(this))
+    open val authSerializations: List<AuthSerialization> by lazy {
+        listOf(SharedPreferencesAuthSerialization(this))
     }
 
     @Volatile
@@ -43,13 +43,13 @@ abstract class AuthService : Service(), LoginListener {
     private lateinit var broadcaster: LocalBroadcastManager
 
     private fun loadAuthState(): AppAuthState {
-        authSerializers.forEachIndexed { i, serializer ->
+        authSerializations.forEachIndexed { i, serializer ->
             val auth = serializer.load()
             if (auth != null) {
                 // ensure auth is stored in the primary serialization method
-                if (i > 0) authSerializers.first().store(auth)
+                if (i > 0) authSerializations.first().store(auth)
                 // remove auth from all other serialization methods
-                authSerializers.drop(1).forEach { it.remove() }
+                authSerializations.drop(1).forEach { it.remove() }
                 return auth
             }
         }
@@ -85,7 +85,7 @@ abstract class AuthService : Service(), LoginListener {
                 currentDelay = null
                 config.updateWithAuthState(this@AuthService, appAuth)
                 config.persistChanges()
-                authSerializers.first().store(appAuth)
+                authSerializations.first().store(appAuth)
             }
         })
     }
@@ -211,7 +211,7 @@ abstract class AuthService : Service(), LoginListener {
         configRegistration?.let { removeLoginListener(it) }
         handler.stop {
             loginManagers.forEach { it.onDestroy() }
-            authSerializers.first().store(appAuth)
+            authSerializations.first().store(appAuth)
         }
     }
 
@@ -266,7 +266,7 @@ abstract class AuthService : Service(), LoginListener {
                     manager.invalidate(appAuth, disableRefresh)
                             ?.also { appAuth = it } != null
                 }) {
-                    authSerializers.first().store(appAuth)
+                    authSerializations.first().store(appAuth)
                     startLogin()
                 }
             }

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/SharedPreferencesAuthSerialization.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/SharedPreferencesAuthSerialization.kt
@@ -12,7 +12,7 @@ import java.io.Serializable
 import java.util.ArrayList
 import java.util.HashSet
 
-class SharedPreferencesAuthSerializer(context: Context): AuthSerializer {
+class SharedPreferencesAuthSerialization(context: Context): AuthSerialization {
     private val prefs = context.getSharedPreferences(AUTH_PREFS, Context.MODE_PRIVATE)
 
     override fun load(): AppAuthState? {
@@ -131,7 +131,7 @@ class SharedPreferencesAuthSerializer(context: Context): AuthSerializer {
     }
 
     companion object {
-        private val logger = LoggerFactory.getLogger(SharedPreferencesAuthSerializer::class.java)
+        private val logger = LoggerFactory.getLogger(SharedPreferencesAuthSerialization::class.java)
 
         private const val LOGIN_PROJECT_ID = "org.radarcns.android.auth.AppAuthState.projectId"
         private const val LOGIN_USER_ID = "org.radarcns.android.auth.AppAuthState.userId"

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/SharedPreferencesAuthSerializer.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/SharedPreferencesAuthSerializer.kt
@@ -1,0 +1,152 @@
+package org.radarbase.android.auth
+
+import android.content.Context
+import android.util.Base64
+import org.json.JSONException
+import org.radarbase.android.auth.portal.ManagementPortalClient
+import org.slf4j.LoggerFactory
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.ObjectInputStream
+import java.io.Serializable
+import java.util.ArrayList
+import java.util.HashSet
+
+class SharedPreferencesAuthSerializer(context: Context): AuthSerializer {
+    private val prefs = context.getSharedPreferences(AUTH_PREFS, Context.MODE_PRIVATE)
+
+    override fun load(): AppAuthState? {
+        val builder = AppAuthState.Builder()
+
+        try {
+            readSerializable(LOGIN_PROPERTIES)
+                    ?.let {
+                        @Suppress("UNCHECKED_CAST")
+                        it as HashMap<String, out Serializable>?
+                    }?.also {
+                        @Suppress("DEPRECATION")
+                        builder.properties(it)
+                    }
+        } catch (ex: Exception) {
+            logger.warn("Cannot read AppAuthState properties", ex)
+        }
+
+        try {
+            readSerializable(LOGIN_HEADERS)
+                    ?.let {
+                        @Suppress("UNCHECKED_CAST")
+                        it as ArrayList<Map.Entry<String, String>>?
+                    }
+                    ?.also { builder.headers += it }
+        } catch (ex: Exception) {
+            logger.warn("Cannot read AppAuthState parseHeaders", ex)
+        }
+
+        try {
+            prefs.getStringSet(LOGIN_APP_SOURCES_LIST, null)
+                    ?.also { builder.parseSourceMetadata(it) }
+        } catch (ex: JSONException) {
+            logger.warn("Cannot parse source metadata parseHeaders", ex)
+        }
+        try {
+            prefs.getStringSet(LOGIN_SOURCE_TYPES, null)
+                    ?.also { builder.parseSourceTypes(it) }
+        } catch (ex: JSONException) {
+            logger.warn("Cannot parse source types parseHeaders", ex)
+        }
+
+        return builder.apply {
+            projectId = prefs.getString(LOGIN_PROJECT_ID, null)
+            userId = prefs.getString(LOGIN_USER_ID, null) ?: return null
+            token = prefs.getString(LOGIN_TOKEN, null)
+            tokenType = prefs.getInt(LOGIN_TOKEN_TYPE, 0)
+            expiration = prefs.getLong(LOGIN_EXPIRATION, 0L)
+            parseAttributes(prefs.getString(LOGIN_ATTRIBUTES, null))
+            parseHeaders(prefs.getString(LOGIN_HEADERS_LIST, null))
+            isPrivacyPolicyAccepted = prefs.getBoolean(LOGIN_PRIVACY_POLICY_ACCEPTED, false)
+            needsRegisteredSources = prefs.getBoolean(LOGIN_NEEDS_REGISTERD_SOURCES, true)
+        }.build()
+    }
+
+    override fun store(state: AppAuthState) {
+        prefs.edit().apply {
+            putString(LOGIN_PROJECT_ID, state.projectId)
+            putString(LOGIN_USER_ID, state.userId)
+            putString(LOGIN_TOKEN, state.token)
+            putString(LOGIN_HEADERS_LIST, state.serializableHeaderList())
+            putString(LOGIN_ATTRIBUTES, state.serializableAttributeList())
+            putInt(LOGIN_TOKEN_TYPE, state.tokenType)
+            putLong(LOGIN_EXPIRATION, state.expiration)
+            putBoolean(LOGIN_PRIVACY_POLICY_ACCEPTED, state.isPrivacyPolicyAccepted)
+            putString(LOGIN_AUTHENTICATION_SOURCE, state.authenticationSource)
+            putBoolean(LOGIN_NEEDS_REGISTERD_SOURCES, state.needsRegisteredSources)
+            remove(LOGIN_PROPERTIES)
+            remove(LOGIN_HEADERS)
+            putStringSet(LOGIN_APP_SOURCES_LIST, HashSet<String>().apply {
+                addAll(state.sourceMetadata.map(SourceMetadata::toJsonString))
+            })
+            putStringSet(LOGIN_SOURCE_TYPES, HashSet<String>().apply {
+                addAll(state.sourceTypes.map(SourceType::toJsonString))
+            })
+            remove(ManagementPortalClient.SOURCES_PROPERTY)
+        }.apply()
+    }
+
+    override fun remove() {
+        prefs.edit().apply {
+            remove(LOGIN_PROJECT_ID)
+            remove(LOGIN_USER_ID)
+            remove(LOGIN_TOKEN)
+            remove(LOGIN_HEADERS_LIST)
+            remove(LOGIN_ATTRIBUTES)
+            remove(LOGIN_TOKEN_TYPE)
+            remove(LOGIN_EXPIRATION)
+            remove(LOGIN_PRIVACY_POLICY_ACCEPTED)
+            remove(LOGIN_AUTHENTICATION_SOURCE)
+            remove(LOGIN_NEEDS_REGISTERD_SOURCES)
+            remove(LOGIN_PROPERTIES)
+            remove(LOGIN_HEADERS)
+            remove(LOGIN_APP_SOURCES_LIST)
+            remove(LOGIN_SOURCE_TYPES)
+            remove(ManagementPortalClient.SOURCES_PROPERTY)
+        }.apply()
+    }
+
+    private fun readSerializable(key: String): Any? {
+        val propString = prefs.getString(key, null)
+        if (propString != null) {
+            val propBytes = Base64.decode(propString, Base64.NO_WRAP)
+            try {
+                ByteArrayInputStream(propBytes).use { bi ->
+                    ObjectInputStream(bi).use { it.readObject() }
+                }
+            } catch (ex: IOException) {
+                logger.warn("Failed to deserialize object {} from preferences", key, ex)
+            } catch (ex: ClassNotFoundException) {
+                logger.warn("Failed to deserialize object {} from preferences", key, ex)
+            }
+
+        }
+        return null
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(SharedPreferencesAuthSerializer::class.java)
+
+        private const val LOGIN_PROJECT_ID = "org.radarcns.android.auth.AppAuthState.projectId"
+        private const val LOGIN_USER_ID = "org.radarcns.android.auth.AppAuthState.userId"
+        private const val LOGIN_TOKEN = "org.radarcns.android.auth.AppAuthState.token"
+        private const val LOGIN_TOKEN_TYPE = "org.radarcns.android.auth.AppAuthState.tokenType"
+        private const val LOGIN_EXPIRATION = "org.radarcns.android.auth.AppAuthState.expiration"
+        internal const val AUTH_PREFS = "org.radarcns.auth"
+        private const val LOGIN_PROPERTIES = "org.radarcns.android.auth.AppAuthState.properties"
+        private const val LOGIN_ATTRIBUTES = "org.radarcns.android.auth.AppAuthState.attributes"
+        private const val LOGIN_HEADERS = "org.radarcns.android.auth.AppAuthState.parseHeaders"
+        private const val LOGIN_HEADERS_LIST = "org.radarcns.android.auth.AppAuthState.headerList"
+        private const val LOGIN_APP_SOURCES_LIST = "org.radarcns.android.auth.AppAuthState.appSourcesList"
+        private const val LOGIN_PRIVACY_POLICY_ACCEPTED = "org.radarcns.android.auth.AppAuthState.isPrivacyPolicyAccepted"
+        private const val LOGIN_AUTHENTICATION_SOURCE = "org.radarcns.android.auth.AppAuthState.authenticationSource"
+        private const val LOGIN_NEEDS_REGISTERD_SOURCES = "org.radarcns.android.auth.AppAuthState.needsRegisteredSources"
+        private const val LOGIN_SOURCE_TYPES = "org.radarcns.android.auth.AppAuthState.sourceTypes"
+    }
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/SourceMetadata.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/SourceMetadata.kt
@@ -54,9 +54,9 @@ class SourceMetadata {
         } catch (ex: JSONException) {
             null
         }
-        this.sourceId = json.optString("sourceId", null)
-        this.sourceName = json.optString("sourceName", null)
-        this.expectedSourceName = json.optString("expectedSourceName", null)
+        this.sourceId = json.optString("sourceId").takeIf { it.isNotEmpty() }
+        this.sourceName = json.optString("sourceName").takeIf { it.isNotEmpty() }
+        this.expectedSourceName = json.optString("expectedSourceName").takeIf { it.isNotEmpty() }
 
         val attr = HashMap<String, String>()
         val attributesJson = json.optJSONObject("attributes")

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/portal/AccessTokenParser.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/portal/AccessTokenParser.kt
@@ -18,7 +18,9 @@ class AccessTokenParser(private val state: AppAuthState) : AuthStringParser {
         try {
             val json = JSONObject(value)
             val accessToken = json.getString("access_token")
-            refreshToken = json.optString("refresh_token", refreshToken)
+            refreshToken = json.optString("refresh_token", refreshToken ?: "")
+                    .takeIf { it.isNotEmpty() }
+                    ?: throw IOException("Missing refresh token")
             return state.alter {
                 attributes[MP_REFRESH_TOKEN_PROPERTY] = refreshToken
                 setHeader("Authorization", "Bearer $accessToken")

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/portal/ManagementPortalClient.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/portal/ManagementPortalClient.kt
@@ -227,8 +227,10 @@ class ManagementPortalClient(managementPortal: ServerConfig, clientId: String, c
             logger.debug("Parsing source from {}", body)
             val responseObject = JSONObject(body)
             source.sourceId = responseObject.getString("sourceId")
-            source.sourceName = responseObject.optString("sourceName", source.sourceId)
-            source.expectedSourceName = responseObject.optString("expectedSourceName", null)
+            source.sourceName = responseObject.optString("sourceName", source.sourceId ?: "")
+                    .takeIf { it.isNotEmpty() }
+            source.expectedSourceName = responseObject.optString("expectedSourceName")
+                    .takeIf { it.isNotEmpty() }
             source.attributes = GetSubjectParser.attributesToMap(
                     responseObject.optJSONObject("attributes"))
         }

--- a/radar-commons-android/src/main/java/org/radarbase/android/auth/portal/ManagementPortalLoginManager.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/auth/portal/ManagementPortalLoginManager.kt
@@ -211,11 +211,13 @@ class ManagementPortalLoginManager(private val listener: AuthService, state: App
         val url = config.getString(MANAGEMENT_PORTAL_URL_KEY)
         val unsafe = config.getBoolean(UNSAFE_KAFKA_CONNECTION, false)
         try {
-            val portalConfig = ServerConfig(url)
-            portalConfig.isUnsafe = unsafe
+            val portalConfig = ServerConfig(url).apply {
+                isUnsafe = unsafe
+            }
             client = ManagementPortalClient(portalConfig,
                     config.getString(OAUTH2_CLIENT_ID),
-                    config.getString(OAUTH2_CLIENT_SECRET, ""), client = restClient)
+                    config.getString(OAUTH2_CLIENT_SECRET, ""),
+                    client = restClient)
                     .also { restClient = it.client }
         } catch (e: MalformedURLException) {
             logger.error("Cannot construct ManagementPortalClient with malformed URL")

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/CacheStore.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/CacheStore.kt
@@ -19,9 +19,10 @@ package org.radarbase.android.data
 import android.content.Context
 import android.os.Process.THREAD_PRIORITY_BACKGROUND
 import org.apache.avro.Schema
-import org.apache.avro.generic.GenericData
-import org.apache.avro.specific.SpecificData
 import org.apache.avro.specific.SpecificRecord
+import org.radarbase.android.BuildConfig
+import org.radarbase.android.data.serialization.SerializationFactory
+import org.radarbase.android.data.serialization.TapeAvroSerializationFactory
 import org.radarbase.android.util.SafeHandler
 import org.radarbase.topic.AvroTopic
 import org.radarbase.util.SynchronizedReference
@@ -31,21 +32,34 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.OutputStreamWriter
+import java.lang.Exception
 import java.nio.charset.StandardCharsets
 import java.util.*
 
-object CacheStore {
+class CacheStore(
+        private val serializationFactories: List<SerializationFactory> = listOf(TapeAvroSerializationFactory())
+) {
     private val tables: MutableMap<String, SynchronizedReference<DataCacheGroup<*, *>>> = HashMap()
     private val handler = SafeHandler.getInstance("DataCache", THREAD_PRIORITY_BACKGROUND)
 
     init {
+        require(serializationFactories.isNotEmpty()) { "Need to specify at least one serialization method" }
+        if (BuildConfig.DEBUG) {
+            check(serializationFactories.none { s1 ->
+                serializationFactories.any { s2 -> s1.fileExtension.endsWith(s2.fileExtension, ignoreCase = true) }
+            }) { "Serialization factories cannot have overlapping extensions, to avoid the wrong deserialization method being chosen."}
+        }
         handler.start()
     }
 
     @Suppress("UNCHECKED_CAST")
     @Synchronized
     @Throws(IOException::class)
-    fun <K: ObservationKey, V: SpecificRecord> getOrCreateCaches(context: Context, topic: AvroTopic<K, V>, config: DataCache.CacheConfiguration): DataCacheGroup<K, V> {
+    fun <K: ObservationKey, V: SpecificRecord> getOrCreateCaches(
+            context: Context,
+            topic: AvroTopic<K, V>,
+            config: DataCache.CacheConfiguration
+    ): DataCacheGroup<K, V> {
         val ref = tables[topic.name] as SynchronizedReference<DataCacheGroup<K, V>>?
                 ?: SynchronizedReference {
                     loadCache(context.cacheDir.absolutePath + "/" + topic.name, topic, config)
@@ -55,21 +69,25 @@ object CacheStore {
     }
 
     @Throws(IOException::class)
-    private fun <K: Any, V: Any> loadCache(base: String, topic: AvroTopic<K, V>, config: DataCache.CacheConfiguration): DataCacheGroup<K, V> {
+    private fun <K: Any, V: Any> loadCache(
+            base: String,
+            topic: AvroTopic<K, V>,
+            config: DataCache.CacheConfiguration
+    ): DataCacheGroup<K, V> {
         val fileBases = getFileBases(base)
         logger.debug("Files for topic {}: {}", topic.name, fileBases)
 
         var activeDataCache: DataCache<K, V>? = null
         val deprecatedDataCaches = ArrayList<ReadableDataCache>()
 
-        for (fileBase in fileBases) {
+        for ((fileBase, serialization) in fileBases) {
             val parser = Schema.Parser()
             val keySchemaFile = File(fileBase + KEY_SCHEMA_EXTENSION)
             val valueSchemaFile = File(fileBase + VALUE_SCHEMA_EXTENSION)
             var keySchema = loadSchema(parser, keySchemaFile)
             var valueSchema = loadSchema(parser, valueSchemaFile)
 
-            val tapeFile = File(fileBase + TAPE_EXTENSION)
+            val tapeFile = File(fileBase + serialization.fileExtension)
             var matches = false
 
             if (keySchema == null) {
@@ -96,8 +114,9 @@ object CacheStore {
                     keySchema, valueSchema,
                     Any::class.java, Any::class.java)
 
-            if (matches
-                    || (keySchema == topic.keySchema && valueSchema == topic.valueSchema)) {
+            if ((matches
+                    || (keySchema == topic.keySchema && valueSchema == topic.valueSchema))
+                    && serialization == serializationFactories.first()) {
                 if (activeDataCache != null) {
                     logger.error("Cannot have more than one active cache")
                 }
@@ -105,11 +124,11 @@ object CacheStore {
                 logger.info("Loading matching data store with schemas {}", tapeFile)
                 activeDataCache = TapeCache(
                         tapeFile, topic, outputTopic, handler,
-                        specificData, genericData, config)
+                        serialization, config)
             } else {
                 logger.debug("Loading deprecated data store {}", tapeFile)
                 deprecatedDataCaches.add(TapeCache(tapeFile, outputTopic as AvroTopic<*, *>,
-                        outputTopic, handler, specificData, genericData, config))
+                        outputTopic, handler, serialization, config))
             }
         }
 
@@ -118,11 +137,12 @@ object CacheStore {
             if (!baseDir.exists() && !baseDir.mkdirs()) {
                 throw IOException("Cannot make data cache directory")
             }
+            val serialization = serializationFactories.first()
             activeDataCache = IntRange(0, 99)
                     .map { "$base/cache-$it" }
-                    .find { it !in fileBases }
+                    .find { fileBase -> fileBases.none { it.first == fileBase } }
                     ?.let { fileBase ->
-                        val tapeFile = File(fileBase + TAPE_EXTENSION)
+                        val tapeFile = File(fileBase + serialization.fileExtension)
                         val keySchemaFile = File(fileBase + KEY_SCHEMA_EXTENSION)
                         val valueSchemaFile = File(fileBase + VALUE_SCHEMA_EXTENSION)
 
@@ -134,74 +154,36 @@ object CacheStore {
                         storeSchema(topic.valueSchema, valueSchemaFile)
 
                         logger.info("Creating new data store {}", tapeFile)
-                        TapeCache(tapeFile, topic, outputTopic, handler, specificData, genericData, config)
+                        TapeCache(tapeFile, topic, outputTopic, handler, serialization, config)
                     } ?: throw IOException("No empty slot to store active data cache in.")
         }
 
         return DataCacheGroup(activeDataCache, deprecatedDataCaches)
     }
 
-    private fun getFileBases(base: String): List<String> {
-        val files = ArrayList<String>(2)
-        if (File(base + TAPE_EXTENSION).isFile) {
-            files += base
-        }
-        val baseDir = File(base)
-        if (baseDir.isDirectory) {
-            files += baseDir.listFiles { _, name -> name.endsWith(TAPE_EXTENSION, ignoreCase = true) }
-                    .map {
-                        val name = it.name
-                        base + "/" + name.substring(0, name.length - TAPE_EXTENSION.length)
-                    }
-        }
-        return files
-    }
+    private fun getFileBases(base: String): List<Pair<String, SerializationFactory>> {
+        val regularFiles = serializationFactories.filter { File(base + it.fileExtension).isFile }
+                .map { base + it.fileExtension to it }
 
-    private val logger = LoggerFactory.getLogger(CacheStore::class.java)
+        val dirFiles = File(base)
+                .takeIf { it.isDirectory }
+                ?.listFiles { _, name -> serializationFactories.any { name.endsWith(it.fileExtension, ignoreCase = true) } }
+                ?.map { f ->
+                    val name = f.name
+                    val factory = serializationFactories.first { name.endsWith(it.fileExtension, ignoreCase = true) }
+                    base + "/" + name.substring(0, name.length - factory.fileExtension.length) to factory
+                }
 
-    internal const val TAPE_EXTENSION = ".tape"
-    internal const val KEY_SCHEMA_EXTENSION = ".key.avsc"
-    internal const val VALUE_SCHEMA_EXTENSION = ".value.avsc"
-
-    val genericData: GenericData = object : GenericData(CacheStore::class.java.classLoader) {
-        override fun isFloat(`object`: Any?): Boolean {
-            return (`object` is Float
-                    && !`object`.isNaN()
-                    && !`object`.isInfinite())
-        }
-
-        override fun isDouble(`object`: Any?): Boolean {
-            return (`object` is Double
-                    && !`object`.isNaN()
-                    && !`object`.isInfinite())
-        }
-    }
-
-    val specificData: SpecificData = object : SpecificData(CacheStore::class.java.classLoader) {
-        override fun isFloat(`object`: Any?): Boolean {
-            return (`object` is Float
-                    && !`object`.isNaN()
-                    && !`object`.isInfinite())
-        }
-
-        override fun isDouble(`object`: Any?): Boolean {
-            return (`object` is Double
-                    && !`object`.isNaN()
-                    && !`object`.isInfinite())
-        }
+        return if (dirFiles != null) regularFiles + dirFiles else regularFiles
     }
 
     private fun loadSchema(parser: Schema.Parser, file: File): Schema? {
         return try {
             if (file.isFile) parser.parse(file) else null
-        } catch (ex: RuntimeException) {
-            logger.error("Failed to load schema", ex)
-            null
-        } catch (ex: IOException) {
+        } catch (ex: Exception) {
             logger.error("Failed to load schema", ex)
             null
         }
-
     }
 
     private fun storeSchema(schema: Schema, file: File) {
@@ -214,6 +196,12 @@ object CacheStore {
         } catch (ex: IOException) {
             logger.error("Cannot write schema", ex)
         }
+    }
 
+    companion object {
+        private val logger = LoggerFactory.getLogger(CacheStore::class.java)
+
+        internal const val KEY_SCHEMA_EXTENSION = ".key.avsc"
+        internal const val VALUE_SCHEMA_EXTENSION = ".value.avsc"
     }
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/DataCache.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/DataCache.kt
@@ -25,7 +25,7 @@ interface DataCache<K, V> : Flushable, ReadableDataCache {
     val topic: AvroTopic<K, V>
 
     /** Add a new measurement to the cache.  */
-    fun addMeasurement(key: K?, value: V?)
+    fun addMeasurement(key: K, value: V)
 
     /** Configuration. */
     var config: CacheConfiguration

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/DataCacheGroup.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/DataCacheGroup.kt
@@ -7,7 +7,8 @@ import java.io.IOException
 
 class DataCacheGroup<K, V>(
         val activeDataCache: DataCache<K, V>,
-        val deprecatedCaches: MutableList<ReadableDataCache>) : Closeable {
+        val deprecatedCaches: MutableList<ReadableDataCache>
+) : Closeable {
 
     val topicName: String = activeDataCache.topic.name
 
@@ -26,7 +27,7 @@ class DataCacheGroup<K, V>(
                 logger.warn("Cannot remove old DataCache file " + tapeFile + " for topic " + storedCache.readTopic.name)
             }
             val name = tapeFile.absolutePath
-            val base = name.substring(0, name.length - CacheStore.TAPE_EXTENSION.length)
+            val base = name.substring(0, name.length - storedCache.serialization.fileExtension.length)
             val keySchemaFile = File(base + CacheStore.KEY_SCHEMA_EXTENSION)
             if (!keySchemaFile.delete()) {
                 logger.warn("Cannot remove old key schema file " + keySchemaFile + " for topic " + storedCache.readTopic.name)

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/ReadableDataCache.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/ReadableDataCache.kt
@@ -16,6 +16,7 @@
 
 package org.radarbase.android.data
 
+import org.radarbase.android.data.serialization.SerializationFactory
 import org.radarbase.data.RecordData
 import org.radarbase.topic.AvroTopic
 import java.io.Closeable
@@ -25,6 +26,7 @@ import java.io.IOException
 interface ReadableDataCache : Closeable {
     /** Get the topic the cache stores.  */
     val readTopic: AvroTopic<Any, Any>
+    val serialization: SerializationFactory
 
     val file: File
     /**

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/SerializationFactory.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/SerializationFactory.kt
@@ -4,8 +4,23 @@ import org.radarbase.data.Record
 import org.radarbase.topic.AvroTopic
 import org.radarbase.util.BackedObjectQueue
 
+/**
+ * Factory for serializer and deserializers for the data cache.
+ */
 interface SerializationFactory {
+    /**
+     * File extension to use with this serialization type. It should be unique across used
+     * serialization factories.
+     */
     val fileExtension: String
+
+    /**
+     * Creates a deserializer for a given topic.
+     */
     fun <K: Any, V: Any> createDeserializer(topic: AvroTopic<K, V>): BackedObjectQueue.Deserializer<Record<K, V>>
+
+    /**
+     * Creates a serializer for a given topic.
+     */
     fun <K: Any, V: Any> createSerializer(topic: AvroTopic<K, V>): BackedObjectQueue.Serializer<Record<K, V>>
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/SerializationFactory.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/SerializationFactory.kt
@@ -1,0 +1,11 @@
+package org.radarbase.android.data.serialization
+
+import org.radarbase.data.Record
+import org.radarbase.topic.AvroTopic
+import org.radarbase.util.BackedObjectQueue
+
+interface SerializationFactory {
+    val fileExtension: String
+    fun <K: Any, V: Any> createDeserializer(topic: AvroTopic<K, V>): BackedObjectQueue.Deserializer<Record<K, V>>
+    fun <K: Any, V: Any> createSerializer(topic: AvroTopic<K, V>): BackedObjectQueue.Serializer<Record<K, V>>
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroDeserializer.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroDeserializer.kt
@@ -15,7 +15,7 @@
  */
 
 
-package org.radarbase.android.data
+package org.radarbase.android.data.serialization
 
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
@@ -32,7 +32,7 @@ import java.io.InputStream
 /**
  * Converts records from an AvroTopic for Tape
  */
-class TapeAvroDeserializer<K, V>(topic: AvroTopic<*, *>, private val specificData: GenericData) : BackedObjectQueue.Deserializer<Record<K, V>> {
+class TapeAvroDeserializer<K, V>(topic: AvroTopic<*, *>, private val avroData: GenericData) : BackedObjectQueue.Deserializer<Record<K, V>> {
     private val decoderFactory: DecoderFactory = DecoderFactory.get()
     private val keyReader: DatumReader<K>
     private val valueReader: DatumReader<V>
@@ -43,9 +43,9 @@ class TapeAvroDeserializer<K, V>(topic: AvroTopic<*, *>, private val specificDat
 
     init {
         @Suppress("UNCHECKED_CAST")
-        keyReader = specificData.createDatumReader(keySchema) as DatumReader<K>
+        keyReader = avroData.createDatumReader(keySchema) as DatumReader<K>
         @Suppress("UNCHECKED_CAST")
-        valueReader = specificData.createDatumReader(valueSchema) as DatumReader<V>
+        valueReader = avroData.createDatumReader(valueSchema) as DatumReader<V>
     }
 
     @Throws(IOException::class)
@@ -67,8 +67,8 @@ class TapeAvroDeserializer<K, V>(topic: AvroTopic<*, *>, private val specificDat
             throw IOException("Failed to deserialize object", ex)
         }
 
-        require(specificData.validate(keySchema, key)
-                && specificData.validate(valueSchema, value)) {
+        require(avroData.validate(keySchema, key)
+                && avroData.validate(valueSchema, value)) {
             "Failed to validate given record in topic $topicName\n\tkey: $key\n\tvalue: $value"
         }
         return Record(key, value)

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroDeserializer.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroDeserializer.kt
@@ -51,10 +51,7 @@ class TapeAvroDeserializer<K, V>(topic: AvroTopic<*, *>, private val avroData: G
     @Throws(IOException::class)
     override fun deserialize(input: InputStream): Record<K, V> {
         // for backwards compatibility
-        var numRead = 0L
-        do {
-            numRead += input.skip(8L - numRead).toInt()
-        } while (numRead < 8L)
+        input.skipFully(8L)
 
         decoder = decoderFactory.binaryDecoder(input, decoder)
 
@@ -72,5 +69,14 @@ class TapeAvroDeserializer<K, V>(topic: AvroTopic<*, *>, private val avroData: G
             "Failed to validate given record in topic $topicName\n\tkey: $key\n\tvalue: $value"
         }
         return Record(key, value)
+    }
+
+    companion object {
+        fun InputStream.skipFully(n: Long) {
+            var numRead = 0L
+            do {
+                numRead += skip(n - numRead)
+            } while (numRead < n)
+        }
     }
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroSerializationFactory.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroSerializationFactory.kt
@@ -1,0 +1,47 @@
+package org.radarbase.android.data.serialization
+
+import org.apache.avro.generic.GenericData
+import org.apache.avro.specific.SpecificData
+import org.radarbase.data.Record
+import org.radarbase.topic.AvroTopic
+import org.radarbase.util.BackedObjectQueue
+
+class TapeAvroSerializationFactory: SerializationFactory {
+    override val fileExtension: String = ".tape"
+
+    private val genericData: GenericData = object : GenericData(TapeAvroSerializationFactory::class.java.classLoader) {
+        override fun isFloat(`object`: Any?): Boolean {
+            return (`object` is Float
+                    && !`object`.isNaN()
+                    && !`object`.isInfinite())
+        }
+
+        override fun isDouble(`object`: Any?): Boolean {
+            return (`object` is Double
+                    && !`object`.isNaN()
+                    && !`object`.isInfinite())
+        }
+    }
+
+    private val specificData: SpecificData = object : SpecificData(TapeAvroSerializationFactory::class.java.classLoader) {
+        override fun isFloat(`object`: Any?): Boolean {
+            return (`object` is Float
+                    && !`object`.isNaN()
+                    && !`object`.isInfinite())
+        }
+
+        override fun isDouble(`object`: Any?): Boolean {
+            return (`object` is Double
+                    && !`object`.isNaN()
+                    && !`object`.isInfinite())
+        }
+    }
+
+    override fun <K: Any, V: Any> createDeserializer(
+            topic: AvroTopic<K, V>
+    ): BackedObjectQueue.Deserializer<Record<K, V>> = TapeAvroDeserializer(topic, genericData)
+
+    override fun <K : Any, V : Any> createSerializer(
+            topic: AvroTopic<K, V>
+    ) = TapeAvroSerializer(topic, specificData)
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroSerializationFactory.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroSerializationFactory.kt
@@ -6,35 +6,22 @@ import org.radarbase.data.Record
 import org.radarbase.topic.AvroTopic
 import org.radarbase.util.BackedObjectQueue
 
+/**
+ * Serialization for binary Avro records to a tape.
+ */
 class TapeAvroSerializationFactory: SerializationFactory {
     override val fileExtension: String = ".tape"
 
+    // The receiving end may have problems with non-numeric representations of floats, so they are not allowed.
     private val genericData: GenericData = object : GenericData(TapeAvroSerializationFactory::class.java.classLoader) {
-        override fun isFloat(`object`: Any?): Boolean {
-            return (`object` is Float
-                    && !`object`.isNaN()
-                    && !`object`.isInfinite())
-        }
-
-        override fun isDouble(`object`: Any?): Boolean {
-            return (`object` is Double
-                    && !`object`.isNaN()
-                    && !`object`.isInfinite())
-        }
+        override fun isFloat(datum: Any?): Boolean = datum is Float && datum.isFinite()
+        override fun isDouble(datum: Any?): Boolean = datum is Double && datum.isFinite()
     }
 
+    // The receiving end may have problems with non-numeric representations of floats, so they are not allowed.
     private val specificData: SpecificData = object : SpecificData(TapeAvroSerializationFactory::class.java.classLoader) {
-        override fun isFloat(`object`: Any?): Boolean {
-            return (`object` is Float
-                    && !`object`.isNaN()
-                    && !`object`.isInfinite())
-        }
-
-        override fun isDouble(`object`: Any?): Boolean {
-            return (`object` is Double
-                    && !`object`.isNaN()
-                    && !`object`.isInfinite())
-        }
+        override fun isFloat(datum: Any?): Boolean = datum is Float && datum.isFinite()
+        override fun isDouble(datum: Any?): Boolean = datum is Double && datum.isFinite()
     }
 
     override fun <K: Any, V: Any> createDeserializer(

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroSerializer.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/serialization/TapeAvroSerializer.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.radarbase.android.data
+package org.radarbase.android.data.serialization
 
 import org.apache.avro.generic.GenericData
 import org.apache.avro.io.BinaryEncoder
@@ -31,12 +31,16 @@ import java.io.OutputStream
 /**
  * Converts records from an AvroTopic for Tape
  */
-class TapeAvroSerializer<K: Any, V: Any>(topic: AvroTopic<K, V>, specificData: GenericData) : BackedObjectQueue.Serializer<Record<K, V>> {
+class TapeAvroSerializer<K: Any, V: Any>(
+        private val topic: AvroTopic<K, V>,
+        private val avroData: GenericData
+) : BackedObjectQueue.Serializer<Record<K, V>> {
+
     private val encoderFactory: EncoderFactory = EncoderFactory.get()
     @Suppress("UNCHECKED_CAST")
-    private val keyWriter: DatumWriter<K> = specificData.createDatumWriter(topic.keySchema) as DatumWriter<K>
+    private val keyWriter: DatumWriter<K> = avroData.createDatumWriter(topic.keySchema) as DatumWriter<K>
     @Suppress("UNCHECKED_CAST")
-    private val valueWriter: DatumWriter<V> = specificData.createDatumWriter(topic.valueSchema) as DatumWriter<V>
+    private val valueWriter: DatumWriter<V> = avroData.createDatumWriter(topic.valueSchema) as DatumWriter<V>
     private var encoder: BinaryEncoder? = null
     private val cachedKey = ChangeApplier(::serializeKey)
 
@@ -63,4 +67,9 @@ class TapeAvroSerializer<K: Any, V: Any>(topic: AvroTopic<K, V>, specificData: G
     companion object {
         private val EMPTY_HEADER = byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0)
     }
+
+    override fun canSerialize(
+            value: Record<K, V>
+    ) = avroData.validate(topic.keySchema, value.key)
+                && avroData.validate(topic.valueSchema, value.value)
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/SourceProvider.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/SourceProvider.kt
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory
 /**
  * RADAR service provider, to bind and configure to a service. It is not thread-safe.
  * @param <T> state that the Service will provide.
-</T> */
+ */
 @Keep
 abstract class SourceProvider<T : BaseSourceState>(protected val radarService: RadarService) {
     private var _connection: SourceServiceConnection<T>? = null

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/AndroidKeyStore.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/AndroidKeyStore.kt
@@ -1,0 +1,28 @@
+package org.radarbase.android.util
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import androidx.annotation.RequiresApi
+import java.security.Key
+import java.security.KeyStore
+import javax.crypto.KeyGenerator
+
+@RequiresApi(Build.VERSION_CODES.M)
+object AndroidKeyStore {
+    fun getOrCreateSecretKey(name: String, algorithm: String, purposes: Int, generatorBuilder: KeyGenParameterSpec.Builder.() -> Unit = {}): Key {
+        val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE)
+        keyStore.load(null)
+        val key = keyStore.getKey(name, null)
+        return if (key != null) {
+            key
+        } else {
+            val keyGenerator = KeyGenerator.getInstance(algorithm, ANDROID_KEY_STORE)
+            keyGenerator.init(KeyGenParameterSpec.Builder(name, purposes)
+                    .apply(generatorBuilder)
+                    .build())
+            keyGenerator.generateKey()
+        }
+    }
+
+    private const val ANDROID_KEY_STORE = "AndroidKeyStore"
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/ChangeApplier.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/ChangeApplier.kt
@@ -1,46 +1,72 @@
 package org.radarbase.android.util
 
-open class ChangeApplier<T: Any, V: Any>(initialValue: T?, private val applier: (T) -> V, private val comparator: T.(T?) -> Boolean = Any::equals) {
+/**
+ * A local cache for a value and its result after transformation.
+ * This assumes that the transformation is completely functional.
+ * @param T value type
+ * @param V result type
+ * @param initialValue initial value. If non-null, no errors will be generated when value or result
+ *                     is called without being called before.
+ * @param applier transformation from value to result. It is only called if no result is cached, or
+ *                the previously passed value is not equal to the currently passed value.
+ * @param comparator how to determine whether two values are equal. Uses equals method by default.
+ */
+open class ChangeApplier<T: Any, V: Any>(
+        initialValue: T?,
+        private val applier: (T) -> V,
+        private val comparator: T.(T?) -> Boolean = Any::equals
+) {
     private var _value: T? = null
 
+    /**
+     * Last value that was passed.
+     * @throws IllegalStateException if no value has been passed yet.
+     */
     @get:Synchronized
     val value: T
         get() = checkNotNull(_value) { "Value is not initialized yet" }
 
+    /**
+     * Last result that was generated.
+     * @throws UninitializedPropertyAccessException if no result has been computed yet.
+     */
     @get:Synchronized
     lateinit var lastResult: V
         private set
 
-    constructor(applier: (T) -> V, comparator: T.(T?) -> Boolean = Any::equals) : this(null, applier, comparator)
+    constructor(
+            applier: (T) -> V,
+            comparator: T.(T?) -> Boolean = Any::equals
+    ) : this(null, applier, comparator)
 
     init {
-        initialValue?.let { value ->
-            applier(value).also {
-                synchronized(this) {
-                    _value = value
-                    lastResult = it
-                }
-            }
-        }
-    }
-
-    fun applyIfChanged(value: T, block: ((V) -> Unit)? = null): V {
-        return if (!isSame(value)) {
-            applier(value)
-                    .also { result ->
-                        synchronized(this) {
-                            _value = value
-                            lastResult = result
-                        }
-                        block?.let { it(result) }
-                    }
-        } else {
-            lastResult
-        }
+        if (initialValue != null) doApply(initialValue)
     }
 
     @Synchronized
-    fun isSame(value: T): Boolean {
-        return value.comparator(_value)
+    private fun doApply(value: T): V {
+        val result = applier(value)
+        synchronized(this) {
+            _value = value
+            lastResult = result
+        }
+        return result
     }
+
+    /**
+     * Set a new value and computes the result. If no change was made to the value, no computation
+     * is performed but the last result is returned. Only if the value is newly computed, an
+     * optional block is run on the result.
+     */
+    fun applyIfChanged(value: T, block: ((V) -> Unit)? = null): V {
+        return if (!isSame(value)) {
+            doApply(value).also {
+                if (block != null) block(it)
+            }
+        } else lastResult
+    }
+
+    /** Whether given value matches the currently cached value. */
+    @Synchronized
+    fun isSame(value: T): Boolean = value.comparator(_value)
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/ChangeRunner.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/ChangeRunner.kt
@@ -1,3 +1,10 @@
 package org.radarbase.android.util
 
-class ChangeRunner<T: Any>(initialValue: T? = null, comparator: T.(T?) -> Boolean = Any::equals) : ChangeApplier<T, T>(initialValue, { it }, comparator)
+/**
+ * A cache that will execute a block if the value changes. This is simply a ChangeApplier that has
+ * identical values for value and result.
+ */
+class ChangeRunner<T: Any>(
+        initialValue: T? = null,
+        comparator: T.(T?) -> Boolean = Any::equals
+) : ChangeApplier<T, T>(initialValue, { it }, comparator)

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/NotificationHandler.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/NotificationHandler.kt
@@ -85,6 +85,20 @@ class NotificationHandler(private val context: Context) {
         createNotificationChannel(channel)
     }
 
+    /**
+     * Creates a notification. Example usage:
+     * ```
+     * notificationHandler.create(NOTIFICATION_CHANNEL_INFO, true) {
+     *     setContentText(getString(R.string.my_text))
+     *     setContentTitle(getString(R.string.myTitle))
+     * }
+     * ```
+     * @param channel channel name to send notification to
+     * @param includeStartIntent whether to include an intent to start the current app when the
+     *                           notification is clicked.
+     * @param buildNotification notification builder function, where notification properties can be
+     *                          set.
+     */
     fun create(channel: String, includeStartIntent: Boolean,
                buildNotification: Notification.Builder.() -> Unit): Notification {
         val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -98,6 +112,24 @@ class NotificationHandler(private val context: Context) {
         }.build()
     }
 
+    /**
+     * Shows a to the user notification. Example usage:
+     * ```
+     * notificationHandler.notify(MY_UNIQUE_ID, NOTIFICATION_CHANNEL_INFO, true) {
+     *     setContentText(getString(R.string.my_text))
+     *     setContentTitle(getString(R.string.myTitle))
+     * }
+     * ```
+     * @param id a number, unique within the app for this notification. If a notification with a
+     *           duplicate ID is used, the current notification with that ID may be removed.
+     * @param channel channel name to send notification to
+     * @param includeStartIntent whether to include an intent to start the current app when the
+     *                           notification is clicked.
+     * @param buildNotification notification builder function, where notification properties can be
+     *                          set.
+     * @return a registration of the notification, which can be used to cancel the notification
+     *         at a later time.
+     */
     fun notify(id: Int, channel: String, includeStartIntent: Boolean,
                buildNotification: Notification.Builder.() -> Unit): NotificationRegistration {
         try {
@@ -164,7 +196,11 @@ class NotificationHandler(private val context: Context) {
         const val NOTIFICATION_CHANNEL_FINAL_ALERT = "org.radarbase.android.NotificationHandler.FINAL_ALERT"
     }
 
-    data class NotificationRegistration(private val manager: NotificationManager?, private val id: Int) {
+    data class NotificationRegistration(
+            private val manager: NotificationManager?,
+            private val id: Int
+    ) {
+        /** Cancels the notification, if possible. */
         fun cancel() {
             try {
                 manager?.cancel(id)

--- a/radar-commons-android/src/main/java/org/radarbase/util/BackedObjectQueue.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/util/BackedObjectQueue.kt
@@ -147,6 +147,12 @@ class BackedObjectQueue<S, T>(
     /** Converts objects into streams.  */
     interface Serializer<S> {
         /**
+         * Check whether given object can be serialized by this serializer.
+         * @return true if the value can be serialized, false otherwise.
+         */
+        fun canSerialize(value: S): Boolean
+
+        /**
          * Serialize an object to given output stream.
          * @param output output, which will not be closed after this call.
          * @throws IOException if a valid object could not be serialized to the stream

--- a/radar-commons-android/src/main/java/org/radarbase/util/QueueFile.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/util/QueueFile.kt
@@ -405,7 +405,7 @@ constructor(private val storage: QueueStorage) : Closeable, Iterable<InputStream
         }
 
         override fun skip(byteCount: Long): Long {
-            val countAvailable = Math.min(byteCount, (totalLength - bytesRead).toLong()).toInt()
+            val countAvailable = byteCount.coerceAtMost((totalLength - bytesRead).toLong()).toInt()
             bytesRead += countAvailable
             storagePosition = header.wrapPosition(storagePosition + countAvailable)
             return countAvailable.toLong()

--- a/radar-commons-android/src/test/java/org/radarbase/android/auth/AppAuthStateTest.kt
+++ b/radar-commons-android/src/test/java/org/radarbase/android/auth/AppAuthStateTest.kt
@@ -1,6 +1,6 @@
 package org.radarbase.android.auth
 
-import org.junit.Assert
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.radarbase.android.auth.portal.ManagementPortalClient
@@ -33,15 +33,15 @@ class AppAuthStateTest {
     }
 
     private fun testProperties(state: AppAuthState, refreshToken: String = "efgh") {
-        Assert.assertEquals("abcd", state.token)
-        Assert.assertEquals(refreshToken, state.getAttribute(ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY))
-        Assert.assertEquals("p", state.projectId)
-        Assert.assertEquals("u", state.userId)
-        Assert.assertTrue(state.isValidFor(9, TimeUnit.SECONDS))
-        Assert.assertFalse(state.isValidFor(11, TimeUnit.SECONDS))
-        Assert.assertEquals(LoginManager.AUTH_TYPE_BEARER.toLong(), state.tokenType.toLong())
-        Assert.assertEquals("Bearer abcd", state.headers[0].value)
-        Assert.assertEquals(sources, state.sourceMetadata)
+        assertEquals("abcd", state.token)
+        assertEquals(refreshToken, state.getAttribute(ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY))
+        assertEquals("p", state.projectId)
+        assertEquals("u", state.userId)
+        assertTrue(state.isValidFor(9, TimeUnit.SECONDS))
+        assertFalse(state.isValidFor(11, TimeUnit.SECONDS))
+        assertEquals(LoginManager.AUTH_TYPE_BEARER.toLong(), state.tokenType.toLong())
+        assertEquals("Bearer abcd", state.headers[0].value)
+        assertEquals(sources, state.sourceMetadata)
     }
 
     @Test

--- a/radar-commons-android/src/test/java/org/radarbase/android/auth/AppAuthStateTest.kt
+++ b/radar-commons-android/src/test/java/org/radarbase/android/auth/AppAuthStateTest.kt
@@ -1,0 +1,56 @@
+package org.radarbase.android.auth
+
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.radarbase.android.auth.portal.ManagementPortalClient
+import java.util.concurrent.TimeUnit
+
+class AppAuthStateTest {
+    private lateinit var state: AppAuthState
+    private lateinit var sources: List<SourceMetadata>
+
+    @Before
+    fun setUp() {
+        sources = listOf(SourceMetadata().apply {
+            type = SourceType(1, "radar", "test", "1.0", true)
+            expectedSourceName = "something"
+        })
+
+        state = AppAuthState {
+            token = "abcd"
+            tokenType = LoginManager.AUTH_TYPE_BEARER
+            projectId = "p"
+            userId = "u"
+            attributes[ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY] = "efgh"
+            sourceMetadata += sources
+            addHeader("Authorization", "Bearer abcd")
+            expiration = System.currentTimeMillis() + 10_000L
+            isPrivacyPolicyAccepted = true
+        }
+
+        testProperties(state)
+    }
+
+    private fun testProperties(state: AppAuthState, refreshToken: String = "efgh") {
+        Assert.assertEquals("abcd", state.token)
+        Assert.assertEquals(refreshToken, state.getAttribute(ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY))
+        Assert.assertEquals("p", state.projectId)
+        Assert.assertEquals("u", state.userId)
+        Assert.assertTrue(state.isValidFor(9, TimeUnit.SECONDS))
+        Assert.assertFalse(state.isValidFor(11, TimeUnit.SECONDS))
+        Assert.assertEquals(LoginManager.AUTH_TYPE_BEARER.toLong(), state.tokenType.toLong())
+        Assert.assertEquals("Bearer abcd", state.headers[0].value)
+        Assert.assertEquals(sources, state.sourceMetadata)
+    }
+
+    @Test
+    fun newBuilder() {
+        val builtState = state.alter {
+            attributes[ManagementPortalClient.MP_REFRESH_TOKEN_PROPERTY] = "else"
+        }
+
+        testProperties(builtState, "else")
+        testProperties(state)
+    }
+}

--- a/radar-commons-android/src/test/java/org/radarbase/android/auth/portal/ManagementPortalClientTest.kt
+++ b/radar-commons-android/src/test/java/org/radarbase/android/auth/portal/ManagementPortalClientTest.kt
@@ -127,9 +127,9 @@ class ManagementPortalClientTest {
         assertEquals("something", `object`.getString("sourceName"))
         assertEquals(0, `object`.getInt("sourceTypeId").toLong())
         val attr = `object`.getJSONObject("attributes")
-        assertEquals(3, `object`.names().length().toLong())
+        assertEquals(3L, `object`.names()?.length()?.toLong())
         assertEquals("0.11", attr.getString("firmware"))
-        assertEquals(1, attr.names().length().toLong())
+        assertEquals(1L, attr.names()?.length()?.toLong())
     }
 
     @Test
@@ -144,7 +144,7 @@ class ManagementPortalClientTest {
         val `object` = JSONObject(body)
         assertEquals("something-With-_others-", `object`.getString("sourceName"))
         assertEquals(0, `object`.getInt("sourceTypeId").toLong())
-        assertEquals(2, `object`.names().length().toLong())
+        assertEquals(2L, `object`.names()?.length()?.toLong())
     }
 
     @Test

--- a/radar-commons-android/src/test/java/org/radarbase/util/BackedObjectQueueTest.java
+++ b/radar-commons-android/src/test/java/org/radarbase/util/BackedObjectQueueTest.java
@@ -17,6 +17,7 @@
 package org.radarbase.util;
 
 import org.apache.avro.generic.GenericRecord;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -45,6 +46,13 @@ public class BackedObjectQueueTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
+    TapeAvroSerializationFactory serialization;
+
+    @Before
+    public void setUp() {
+        serialization = new TapeAvroSerializationFactory();
+    }
+
     @Test
     public void testBinaryObject() throws IOException {
         File file = folder.newFile();
@@ -61,12 +69,10 @@ public class BackedObjectQueueTest {
                 ObservationKey.getClassSchema(), ActiveAudioRecording.getClassSchema(),
                 GenericRecord.class, GenericRecord.class);
 
-        TapeAvroSerializationFactory serializerFactory = new TapeAvroSerializationFactory();
-
         try (BackedObjectQueue<Record<ObservationKey, ActiveAudioRecording>, Record<GenericRecord, GenericRecord>> queue = new BackedObjectQueue<>(
                 QueueFile.Companion.newMapped(file, 450000000),
-                serializerFactory.createSerializer(topic),
-                serializerFactory.createDeserializer(outputTopic))) {
+                serialization.createSerializer(topic),
+                serialization.createDeserializer(outputTopic))) {
 
             ByteBuffer buffer = ByteBuffer.wrap(data);
             Record<ObservationKey, ActiveAudioRecording> record = new Record<>(
@@ -77,8 +83,8 @@ public class BackedObjectQueueTest {
         }
         try (BackedObjectQueue<Record<ObservationKey, ActiveAudioRecording>, Record<GenericRecord, GenericRecord>> queue = new BackedObjectQueue<>(
                 QueueFile.Companion.newMapped(file, 450000000),
-                serializerFactory.createSerializer(topic),
-                serializerFactory.createDeserializer(outputTopic))) {
+                serialization.createSerializer(topic),
+                serialization.createDeserializer(outputTopic))) {
             Record<GenericRecord, GenericRecord> result = queue.peek();
             assertNotNull(result);
             assertArrayEquals(data, ((ByteBuffer) result.value.get("data")).array());
@@ -96,13 +102,11 @@ public class BackedObjectQueueTest {
                 ObservationKey.getClassSchema(), ObservationKey.getClassSchema(),
                 GenericRecord.class, GenericRecord.class);
 
-        TapeAvroSerializationFactory serializerFactory = new TapeAvroSerializationFactory();
-
         BackedObjectQueue<Record<ObservationKey, ObservationKey>, Record<GenericRecord, GenericRecord>> queue;
         queue = new BackedObjectQueue<>(
                 QueueFile.Companion.newMapped(file, 10000),
-                serializerFactory.createSerializer(topic),
-                serializerFactory.createDeserializer(outputTopic));
+                serialization.createSerializer(topic),
+                serialization.createDeserializer(outputTopic));
 
         Record<ObservationKey, ObservationKey> record = new Record<>(
                 new ObservationKey("test", "a", "b"),
@@ -126,13 +130,11 @@ public class BackedObjectQueueTest {
                 GenericRecord.class, GenericRecord.class);
 
 
-        TapeAvroSerializationFactory serializerFactory = new TapeAvroSerializationFactory();
-
         BackedObjectQueue<Record<ObservationKey, PhoneLight>, Record<GenericRecord, GenericRecord>> queue;
         queue = new BackedObjectQueue<>(
                 QueueFile.Companion.newMapped(file, 10000),
-                serializerFactory.createSerializer(topic),
-                serializerFactory.createDeserializer(outputTopic));
+                serialization.createSerializer(topic),
+                serialization.createDeserializer(outputTopic));
 
         double now = System.currentTimeMillis() / 1000d;
         Record<ObservationKey, PhoneLight> record = new Record<>(

--- a/radar-commons-android/src/test/java/org/radarbase/util/QueueFileTest.kt
+++ b/radar-commons-android/src/test/java/org/radarbase/util/QueueFileTest.kt
@@ -19,7 +19,6 @@ package org.radarbase.util
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.rules.TemporaryFolder
 import org.slf4j.LoggerFactory
 import java.io.IOException
@@ -30,10 +29,6 @@ class QueueFileTest {
     @Rule
     @JvmField
     var folder = TemporaryFolder()
-
-    @Rule
-    @JvmField
-    var exception: ExpectedException = ExpectedException.none()
 
     @Test
     @Throws(Exception::class)
@@ -47,8 +42,7 @@ class QueueFileTest {
             out.next()
             out.write(buffer)
             out.next()
-            exception.expect(IllegalStateException::class.java)
-            out.write(buffer)
+            assertThrows(IllegalStateException::class.java) { out.write(buffer) }
         }
     }
 
@@ -75,8 +69,7 @@ class QueueFileTest {
                 out.next()
                 out.write(buffer)
                 out.next()
-                exception.expect(IllegalStateException::class.java)
-                out.write(buffer)
+                assertThrows(IllegalStateException::class.java) { out.write(buffer) }
             }
         } catch (ex: IOException) {
             logger.info("Queue file cannot be written to {}", queue)
@@ -178,8 +171,9 @@ class QueueFileTest {
         iter.next().use { `in` -> assertEquals(2, `in`.read()) }
         assertFalse(iter.hasNext())
 
-        exception.expect(NoSuchElementException::class.java)
-        iter.next()
+        assertThrows(NoSuchElementException::class.java) {
+            iter.next()
+        }
     }
 
     @Test


### PR DESCRIPTION
- allows apps to have their own serialization mechanisms.
  - `AppAuth` does not serialise itself anymore, but it is handled by a `AuthSerialization` implementation. Moved the default implementation (with `SharedPreferences`) to `SharedPreferencesAuthSerialization`.
  - `TapeCache` no longer constructs its own serialisers, but gets them from a `SerializationFactory`. Moved the default implementation to `TapeAvroSerializationFactory`.
  - `CacheStore` is no longer a singleton, but a single property of `RadarService`
  - `AuthSerialization` implementation is a single property of `AuthService`.
- use Android functionality for generating hash keys.
- cleaned up some code.
- added some docstrings