### PR TITLE
Release 1.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ repositories {
     maven { url 'http://dl.bintray.com/radar-base/org.radarbase' }
 }
 dependencies {
-    api 'org.radarbase:radar-commons-android:1.0.6'
+    api 'org.radarbase:radar-commons-android:1.0.7'
 }
 ```
 
@@ -49,7 +49,7 @@ Include additional plugins by adding:
 
 ```gradle
 dependencies {
-    implementation 'org.radarbase:<plugin name>:1.0.6'
+    implementation 'org.radarbase:<plugin name>:1.0.7'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
     ext.issueUrl = 'https://github.com/' + githubRepoName + '/issues'
     ext.website = 'http://radar-base.org'
 
-    version = '1.0.7-SNAPSHOT'
+    version = '1.0.7'
     group = 'org.radarbase'
 
     ext.versionCode = 41

--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,10 @@ allprojects {
     ext.issueUrl = 'https://github.com/' + githubRepoName + '/issues'
     ext.website = 'http://radar-base.org'
 
-    version = '1.0.6'
+    version = '1.0.7-SNAPSHOT'
     group = 'org.radarbase'
 
-    ext.versionCode = 40
+    ext.versionCode = 41
 }
 
 subprojects {

--- a/plugins/radar-android-empatica/src/main/res/values/strings.xml
+++ b/plugins/radar-android-empatica/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="empaticaE4DisplayName">E4</string>
-    <string name="e4DeviceName">E4 $1%s</string>
+    <string name="e4DeviceName">E4 %1$s</string>
     <string name="empatica_e4_explanation">Empatica E4 collects heart rate, blood volume pulse and
         acceleration, and electrodermal activity. Connect an Empatica E4 by pressing the
         power-button. It needs Bluetooth and location permissions to communicate efficiently. The

--- a/radar-commons-android/src/androidTest/java/org/radarbase/android/data/TapeCacheTest.kt
+++ b/radar-commons-android/src/androidTest/java/org/radarbase/android/data/TapeCacheTest.kt
@@ -79,7 +79,7 @@ class TapeCacheTest {
         }
         tapeCache = TapeCache(folder.newFile(), topic,
                 outputTopic, handler, serializationFactory,
-                CacheConfiguration(100, 4096, CacheConfiguration.QueueFileFactory.MAPPED))
+                CacheConfiguration(100, 4096, CacheConfiguration.QueueFileFactory.DIRECT))
 
         key = ObservationKey("test", "a", "b")
         val time = System.currentTimeMillis() / 1000.0

--- a/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
@@ -110,7 +110,7 @@ abstract class MainActivity : AppCompatActivity() {
                 .register(RADAR_CONFIGURATION_CHANGED) { _, _ -> onConfigChanged() }
 
         // Start the UI thread
-        uiRefreshRate = configuration.latestConfig.getLong(UI_REFRESH_RATE_KEY)
+        uiRefreshRate = configuration.latestConfig.getLong(UI_REFRESH_RATE_KEY, 250L)
     }
 
     @CallSuper

--- a/radar-commons-android/src/main/java/org/radarbase/android/config/AppConfigRadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/config/AppConfigRadarConfiguration.kt
@@ -100,6 +100,9 @@ class AppConfigRadarConfiguration(context: Context) : RemoteConfig {
 
                         retryDelay.reset()
                         RadarConfiguration.RemoteConfigStatus.FETCHED
+                    } else if (response.code == 404) {
+                        logger.warn("Cannot query appconfig at {}. Disabling app-config.", request.url)
+                        RadarConfiguration.RemoteConfigStatus.UNAVAILABLE
                     } else {
                         logger.error("Failed to fetch remote config using {} (HTTP status {}): {}",
                                 call.request(), response.code, response.body?.string())

--- a/radar-commons-android/src/main/java/org/radarbase/android/config/FirebaseRemoteConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/config/FirebaseRemoteConfiguration.kt
@@ -21,7 +21,6 @@ import android.os.Handler
 import android.os.Looper
 import androidx.annotation.XmlRes
 import com.google.android.gms.common.ConnectionResult
-import com.google.android.gms.common.GoogleApiAvailabilityLight
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -85,12 +84,7 @@ class FirebaseRemoteConfiguration(private val context: Context, inDevelopmentMod
                     .addOnFailureListener(onFailureListener)
         }
 
-        val googleApi = GoogleApiAvailabilityLight.getInstance()
-        status = if (googleApi.isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS) {
-            RadarConfiguration.RemoteConfigStatus.READY
-        } else {
-            RadarConfiguration.RemoteConfigStatus.UNAVAILABLE
-        }
+        status = RadarConfiguration.RemoteConfigStatus.READY
     }
 
     /**

--- a/radar-commons-android/src/main/java/org/radarbase/android/splash/SplashActivity.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/splash/SplashActivity.kt
@@ -170,7 +170,7 @@ abstract class SplashActivity : AppCompatActivity() {
 
     protected open fun startConfigReceiver() {
         updateState(STATE_FETCHING_CONFIG)
-        config.fetch()
+        config.forceFetch()
         radarConfig.config.observe(this, configObserver)
         configReceiver = true
     }


### PR DESCRIPTION
Changes since version 1.0.6:
- Wait 500 milliseconds after stopping scanning before connecting to E4.
- Fixed reference in `connectedCheck`
- Avoid crashing on missing ui_refresh_rate_millis in misconfigured app.
- Force refresh config on splash
- App config service is set to unavailable if it returns 404.