### PR TITLE
add fine location

### DIFF
--- a/plugins/radar-android-empatica/src/main/AndroidManifest.xml
+++ b/plugins/radar-android-empatica/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 

--- a/plugins/radar-android-empatica/src/main/java/org/radarbase/passive/empatica/E4Provider.kt
+++ b/plugins/radar-android-empatica/src/main/java/org/radarbase/passive/empatica/E4Provider.kt
@@ -33,6 +33,7 @@ open class E4Provider(radarService: RadarService) : SourceProvider<E4State>(rada
 
     override val permissionsNeeded = listOf(
         ACCESS_COARSE_LOCATION,
+        ACCESS_FINE_LOCATION,
         BLUETOOTH,
         BLUETOOTH_ADMIN,
     )

--- a/plugins/radar-android-faros/src/main/AndroidManifest.xml
+++ b/plugins/radar-android-faros/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <application>
         <service android:name=".FarosService"

--- a/plugins/radar-android-faros/src/main/java/org/radarbase/passive/bittium/FarosProvider.kt
+++ b/plugins/radar-android-faros/src/main/java/org/radarbase/passive/bittium/FarosProvider.kt
@@ -39,6 +39,7 @@ class FarosProvider(radarService: RadarService) : SourceProvider<FarosState>(rad
 
     override val permissionsNeeded: List<String> = listOf(
         ACCESS_COARSE_LOCATION,
+        ACCESS_FINE_LOCATION,
         BLUETOOTH,
         BLUETOOTH_ADMIN,
     )

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneBluetoothProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneBluetoothProvider.kt
@@ -46,6 +46,7 @@ open class PhoneBluetoothProvider(radarService: RadarService) : SourceProvider<B
     override val permissionsNeeded: List<String> = listOf(
         Manifest.permission.BLUETOOTH_ADMIN,
         Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.ACCESS_FINE_LOCATION,
     )
 
     override val featuresNeeded: List<String> = listOf(PackageManager.FEATURE_BLUETOOTH)


### PR DESCRIPTION
needed for bluetooth scanning in android 10+.

According to this https://developer.android.com/about/versions/10/privacy/changes#location-telephony-bluetooth-wifi you need to have the fine location for bluetooth scanning in android 10+.

Relevant logs-

```
2021-03-19 14:19:18.918 27558-1494/org.radarcns.android I/EmpaDeviceManager: Login ok
2021-03-19 14:19:18.918 27558-1494/org.radarcns.android D/EmpaDeviceManager: Empaconf & Empasign ok
2021-03-19 14:19:18.928 27558-27558/org.radarcns.android D/EmpaDeviceManager: HnU - 0 sessions
2021-03-19 14:19:18.928 27558-27558/org.radarcns.android I/EmpaDeviceManager: UBMDS: uploadNextMemoryDumpSession • started
2021-03-19 14:19:18.928 27558-27558/org.radarcns.android D/EmpaDeviceManager: Good Sessions: 0
2021-03-19 14:19:18.929 27558-27558/org.radarcns.android I/pRMT:E4Manager: Empatica session event SESSION_FINISHED with progress 0.0
2021-03-19 14:19:18.934 27558-27558/org.radarcns.android I/pRMT:E4Manager: 114059509: Updated E4 status to READY
2021-03-19 14:19:18.943 27558-1437/org.radarcns.android I/BluetoothAdapter: STATE_ON
2021-03-19 14:19:18.944 27558-1437/org.radarcns.android I/BluetoothAdapter: STATE_ON
2021-03-19 14:19:18.945 27558-1437/org.radarcns.android I/BluetoothAdapter: STATE_ON
2021-03-19 14:19:18.947 27558-1437/org.radarcns.android I/BluetoothAdapter: STATE_ON
2021-03-19 14:19:18.948 27558-1437/org.radarcns.android D/BluetoothLeScanner: Start Scan with callback
2021-03-19 14:19:18.950 1354-3096/? D/BtGatt.ContextMap: add() - appUid: 10409, appPid: 27558, appName: org.radarcns.android
2021-03-19 14:19:18.951 1354-2274/? I/bt_stack: [INFO:gatt_api.cc(950)] GATT_Register 118bd506-b95e-440d-8726-80d97581423f
2021-03-19 14:19:18.951 1354-2274/? I/bt_stack: [INFO:gatt_api.cc(994)] allocated gatt_if=15
2021-03-19 14:19:18.952 1354-1517/? D/BtGatt.GattService: onScannerRegistered() - UUID=118bd506-b95e-440d-8726-80d97581423f, scannerId=15, status=0
2021-03-19 14:19:18.953 27558-32590/org.radarcns.android D/BluetoothLeScanner: onScannerRegistered() - status=0 scannerId=15 mScannerId=0
2021-03-19 14:19:18.954 1354-3096/? I/BluetoothAdapter: STATE_ON
2021-03-19 14:19:18.955 1354-3096/? E/BluetoothUtils: Permission denial: Need ACCESS_FINE_LOCATION permission to get scan results
2021-03-19 14:19:18.957 27558-1437/org.radarcns.android I/pRMT:E4Manager: Started scanning
2021-03-19 14:19:18.959 1354-2015/? I/BluetoothAdapter: STATE_ON
2021-03-19 14:19:18.963 1354-2018/? E/BtGatt.GattService: [GSIM LOG]: gsimLogHandler, msg: MESSAGE_SCAN_START, appName: org.radarcns.android, scannerId: 15, reportDelayMillis=0
2021-03-19 14:19:18.963 1354-2015/? I/BluetoothAdapter: STATE_ON
2021-03-19 14:19:18.964 1354-2015/? I/BluetoothAdapter: STATE_ON
2021-03-19 14:19:18.965 982-1032/? I/AppOps: commitUidPendingStateLocked() :: UID - 10409, 200 > 200, 7 > 7
2021-03-19 14:19:18.971 1354-2015/? D/BtGatt.ScanManager: configureFilterParamter() : onFoundTimeout | onLostTimeout | onFoundCount | numOfTrackingEntries | scanFilterRssiThreshold | trackableScanFilterRssiThreshold | matchMode
2021-03-19 14:19:18.971 1354-2015/? D/BtGatt.ScanManager: configureFilterParamter() : __________500__|________10000__|___________1__|___________________0__|___________________-128__|____________________________-128__|________1_
2021-03-19 14:19:18.975 1354-2274/? W/bt_btm: btm_ble_disable_resolving_list() rl_state = 0x0, rl_mask = 0x2, to_resume = 1
2021-03-19 14:19:18.975 1354-2274/? W/bt_btm: btm_ble_disable_resolving_list() rl_state = 0x0, rl_mask = 0x2, to_resume = 1
```