### PR TITLE
Throttle Android sensor events to the specified level

### DIFF
--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorManager.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorManager.kt
@@ -165,19 +165,19 @@ class PhoneSensorManager(context: PhoneSensorService) : AbstractSourceManager<Ph
             val now = SystemClock.uptimeMillis()
             val timeUntilIntervalEnds = latestUpload + delay - now
 
-            if (timeUntilIntervalEnds <= 0) {
-                // first event in the interval, send it
+            if (timeUntilIntervalEnds <= 0) { // first event in the interval
                 latestSensorUpload.put(sensorType, now)
                 // don't send any event from previous intervals
                 latestSensorFuture[sensorType]?.cancel()
                 processSensorEvent(sensorType, event)
-            } else {
-                // later event in the interval, store it
+
+            } else { // later event in the interval
+                // store it
                 latestSensorEvent[sensorType] = event
-                // if it does not exist yet, delay sending the latest event.
-                // It may be cancelled if other events come in (in the branch above)
+                // delay sending it
                 if (latestSensorFuture[sensorType] == null) {
                     // wait up to 1 interval more after the current interval ends before sending this value.
+                    // it may be cancelled if other events come in (in the branch above)
                     latestSensorFuture[sensorType] = mHandler.delay(timeUntilIntervalEnds + delay) {
                         processSensorEvent(sensorType, latestSensorEvent[sensorType])
                     }

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorManager.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorManager.kt
@@ -158,8 +158,7 @@ class PhoneSensorManager(context: PhoneSensorService) : AbstractSourceManager<Ph
             // Ignore disabled sensors
             if (delay <= 0) return@execute
 
-            val sendState = sensorSendStates[sensorType]
-                ?: SensorSendState().also { sensorSendStates.put(sensorType, it) }
+            val sendState = sensorSendStates.computeIfAbsent(sensorType) { SensorSendState() }
 
             if (sendState.mayStartNewInterval(delay)) {
                 processSensorEvent(sensorType, event, sendState)
@@ -313,6 +312,9 @@ class PhoneSensorManager(context: PhoneSensorService) : AbstractSourceManager<Ph
             return size() == other.size()
                     && (0 until size()).all { keyAt(it) == other.keyAt(it) && valueAt(it) == other.valueAt(it) }
         }
+
+        private inline fun <T> SparseArray<T>.computeIfAbsent(key: Int, compute: () -> T) = get(key)
+            ?: compute().also { put(key, it) }
 
         data class SensorSendState(
             var lastSendTime: Long = 0,

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorManager.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorManager.kt
@@ -173,14 +173,17 @@ class PhoneSensorManager(context: PhoneSensorService) : AbstractSourceManager<Ph
 
             } else { // later event in the interval
                 // store it
-                latestSensorEvent[sensorType] = event
+                latestSensorEvent.put(sensorType, event)
                 // delay sending it
                 if (latestSensorFuture[sensorType] == null) {
                     // wait up to 1 interval more after the current interval ends before sending this value.
                     // it may be cancelled if other events come in (in the branch above)
-                    latestSensorFuture[sensorType] = mHandler.delay(timeUntilIntervalEnds + delay) {
-                        processSensorEvent(sensorType, latestSensorEvent[sensorType])
-                    }
+                    latestSensorFuture.put(
+                        sensorType,
+                        mHandler.delay(timeUntilIntervalEnds + delay) {
+                            processSensorEvent(sensorType, latestSensorEvent[sensorType])
+                        },
+                    )
                 }
             }
         }
@@ -188,8 +191,8 @@ class PhoneSensorManager(context: PhoneSensorService) : AbstractSourceManager<Ph
 
     private fun processSensorEvent(sensorType: Int, event: SensorEvent?) {
         // When sending an event, discard all past events
-        latestSensorEvent[sensorType] = null
-        latestSensorFuture[sensorType] = null
+        latestSensorEvent.put(sensorType, null)
+        latestSensorFuture.put(sensorType, null)
         event ?: return
         when (sensorType) {
             Sensor.TYPE_ACCELEROMETER -> processAcceleration(event)


### PR DESCRIPTION
This means that
- if a sensor is disabled in settings, it will never send
any records
- if more than one event per interval is emitted, only the first one is
  sent. The last event that is emitted within the interval is also
  emitted, if no events occur in the interval after it.