### PR TITLE
Broadcasting all permissions of onActivityResult()

### DIFF
--- a/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
@@ -45,7 +45,7 @@ open class PermissionHandler(
 
             val result = if (granted) PERMISSION_GRANTED else PERMISSION_DENIED
             broadcaster.send(RadarService.ACTION_PERMISSIONS_GRANTED) {
-                putExtra(RadarService.EXTRA_PERMISSIONS, arrayOf(LOCATION_SERVICE))
+                putExtra(RadarService.EXTRA_PERMISSIONS, arrayOf(permission))
                 putExtra(RadarService.EXTRA_GRANT_RESULTS, intArrayOf(result))
             }
 


### PR DESCRIPTION
**PermissionHandler** is not broadcasting the `PACKAGE_USAGE_STATS`, `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, and `SYSTEM_ALERT_WINDOW` to **RadarService**. It is always sending LOCATION_SERVICE as an extra permission. 
Even though it is working fine without this as well, it is just for internal broadcast and logging.
