### PR TITLE
Optimizing the Google Places plugin for better device resource utilization

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ publish_plugin_version=2.0.0
 versions_plugin_version=0.51.0
 
 radar_commons_version=0.15.0
-radar_schemas_commons_version=0.8.7
+radar_schemas_commons_version=0.8.9
 
 radar_faros_sdk_version=0.1.0
 

--- a/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesManager.kt
+++ b/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesManager.kt
@@ -206,15 +206,15 @@ class GooglePlacesManager(service: GooglePlacesService, @get: Synchronized priva
 
     private fun doSend(places: List<PlaceLikelihood>) {
         places.forEach { likelihood ->
-            val types = likelihood.place.types?.map { it.toPlacesType() }
+            val types = likelihood.place.placeTypes
             val placeId: String? = if (shouldFetchPlaceId) likelihood.place.id else null
             val placesInfoBuilder = GooglePlacesInfo.newBuilder().apply {
                 time = currentTime
                 timeReceived = currentTime
-                type1 = types?.getOrNull(0)
-                type2 = types?.getOrNull(1)
-                type3 = types?.getOrNull(2)
-                type4 = types?.getOrNull(3)
+                placeType1 = types?.get(0)
+                placeType2 = types?.get(1)
+                placeType3 = types?.get(2)
+                placeType4 = types?.get(3)
                 this.likelihood = likelihood.likelihood
                 fromBroadcast = fromBroadcastRegistration
                 city = null
@@ -339,148 +339,5 @@ class GooglePlacesManager(service: GooglePlacesService, @get: Synchronized priva
         private const val COUNTRY_KEY = "country"
         const val NUMBER_OF_ATTEMPTS_KEY = "number_of_attempts_key"
         const val DEVICE_LOCATION_CHANGED = "org.radarbase.passive.google.places.GooglePlacesManager.DEVICE_LOCATION_CHANGED"
-
-        private fun Place.Type.toPlacesType(): PlacesType? = when (this) {
-            Place.Type.ACCOUNTING -> PlacesType.ACCOUNTING
-            Place.Type.ADMINISTRATIVE_AREA_LEVEL_1 -> PlacesType.ADMINISTRATIVE_AREA_LEVEL_1
-            Place.Type.ADMINISTRATIVE_AREA_LEVEL_2 -> PlacesType.ADMINISTRATIVE_AREA_LEVEL_2
-            Place.Type.ADMINISTRATIVE_AREA_LEVEL_3 -> PlacesType.ADMINISTRATIVE_AREA_LEVEL_3
-            Place.Type.ADMINISTRATIVE_AREA_LEVEL_4 -> PlacesType.ADMINISTRATIVE_AREA_LEVEL_4
-            Place.Type.ADMINISTRATIVE_AREA_LEVEL_5 -> PlacesType.ADMINISTRATIVE_AREA_LEVEL_5
-            Place.Type.AIRPORT -> PlacesType.AIRPORT
-            Place.Type.AMUSEMENT_PARK -> PlacesType.AMUSEMENT_PARK
-            Place.Type.AQUARIUM -> PlacesType.AQUARIUM
-            Place.Type.ARCHIPELAGO -> PlacesType.ARCHIPELAGO
-            Place.Type.ART_GALLERY -> PlacesType.ART_GALLERY
-            Place.Type.ATM -> PlacesType.ATM
-            Place.Type.BAKERY -> PlacesType.BAKERY
-            Place.Type.BANK -> PlacesType.BANK
-            Place.Type.BAR -> PlacesType.BAR
-            Place.Type.BEAUTY_SALON -> PlacesType.BEAUTY_SALON
-            Place.Type.BICYCLE_STORE -> PlacesType.BICYCLE_STORE
-            Place.Type.BOOK_STORE -> PlacesType.BOOK_STORE
-            Place.Type.BOWLING_ALLEY -> PlacesType.BOWLING_ALLEY
-            Place.Type.BUS_STATION -> PlacesType.BUS_STATION
-            Place.Type.CAFE -> PlacesType.CAFE
-            Place.Type.CAMPGROUND -> PlacesType.CAMPGROUND
-            Place.Type.CAR_DEALER -> PlacesType.CAR_DEALER
-            Place.Type.CAR_RENTAL -> PlacesType.CAR_RENTAL
-            Place.Type.CAR_REPAIR -> PlacesType.CAR_REPAIR
-            Place.Type.CAR_WASH -> PlacesType.CAR_WASH
-            Place.Type.CASINO -> PlacesType.CASINO
-            Place.Type.CEMETERY -> PlacesType.CEMETERY
-            Place.Type.CHURCH -> PlacesType.CHURCH
-            Place.Type.CITY_HALL -> PlacesType.CITY_HALL
-            Place.Type.CLOTHING_STORE -> PlacesType.CLOTHING_STORE
-            Place.Type.COLLOQUIAL_AREA -> PlacesType.COLLOQUIAL_AREA
-            Place.Type.CONTINENT -> PlacesType.CONTINENT
-            Place.Type.CONVENIENCE_STORE -> PlacesType.CONVENIENCE_STORE
-            Place.Type.COUNTRY -> PlacesType.COUNTRY
-            Place.Type.COURTHOUSE -> PlacesType.COURTHOUSE
-            Place.Type.DENTIST -> PlacesType.DENTIST
-            Place.Type.DEPARTMENT_STORE -> PlacesType.DEPARTMENT_STORE
-            Place.Type.DOCTOR -> PlacesType.DOCTOR
-            Place.Type.DRUGSTORE -> PlacesType.DRUGSTORE
-            Place.Type.ELECTRICIAN -> PlacesType.ELECTRICIAN
-            Place.Type.ELECTRONICS_STORE -> PlacesType.ELECTRONICS_STORE
-            Place.Type.EMBASSY -> PlacesType.EMBASSY
-            Place.Type.ESTABLISHMENT -> PlacesType.ESTABLISHMENT
-            Place.Type.FINANCE -> PlacesType.FINANCE
-            Place.Type.FIRE_STATION -> PlacesType.FIRE_STATION
-            Place.Type.FLOOR -> PlacesType.FLOOR
-            Place.Type.FLORIST -> PlacesType.FLORIST
-            Place.Type.FOOD -> PlacesType.FOOD
-            Place.Type.FUNERAL_HOME -> PlacesType.FUNERAL_HOME
-            Place.Type.FURNITURE_STORE -> PlacesType.FURNITURE_STORE
-            Place.Type.GAS_STATION -> PlacesType.GAS_STATION
-            Place.Type.GENERAL_CONTRACTOR -> PlacesType.GENERAL_CONTRACTOR
-            Place.Type.GEOCODE -> PlacesType.GEOCODE
-            Place.Type.GROCERY_OR_SUPERMARKET -> PlacesType.GROCERY_OR_SUPERMARKET
-            Place.Type.GYM -> PlacesType.GYM
-            Place.Type.HAIR_CARE -> PlacesType.HAIR_CARE
-            Place.Type.HARDWARE_STORE -> PlacesType.HARDWARE_STORE
-            Place.Type.HEALTH -> PlacesType.HEALTH
-            Place.Type.HINDU_TEMPLE -> PlacesType.HINDU_TEMPLE
-            Place.Type.HOME_GOODS_STORE -> PlacesType.HOME_GOODS_STORE
-            Place.Type.HOSPITAL -> PlacesType.HOSPITAL
-            Place.Type.INSURANCE_AGENCY -> PlacesType.INSURANCE_AGENCY
-            Place.Type.INTERSECTION -> PlacesType.INTERSECTION
-            Place.Type.JEWELRY_STORE -> PlacesType.JEWELRY_STORE
-            Place.Type.LAUNDRY -> PlacesType.LAUNDRY
-            Place.Type.LAWYER -> PlacesType.LAWYER
-            Place.Type.LIBRARY -> PlacesType.LIBRARY
-            Place.Type.LIGHT_RAIL_STATION -> PlacesType.LIGHT_RAIL_STATION
-            Place.Type.LIQUOR_STORE -> PlacesType.LIQUOR_STORE
-            Place.Type.LOCAL_GOVERNMENT_OFFICE -> PlacesType.LOCAL_GOVERNMENT_OFFICE
-            Place.Type.LOCALITY -> PlacesType.LOCALITY
-            Place.Type.LOCKSMITH -> PlacesType.LOCKSMITH
-            Place.Type.LODGING -> PlacesType.LODGING
-            Place.Type.MEAL_DELIVERY -> PlacesType.MEAL_DELIVERY
-            Place.Type.MEAL_TAKEAWAY -> PlacesType.MEAL_TAKEAWAY
-            Place.Type.MOSQUE -> PlacesType.MOSQUE
-            Place.Type.MOVIE_RENTAL -> PlacesType.MOVIE_RENTAL
-            Place.Type.MOVIE_THEATER -> PlacesType.MOVIE_THEATER
-            Place.Type.MOVING_COMPANY -> PlacesType.MOVING_COMPANY
-            Place.Type.MUSEUM -> PlacesType.MUSEUM
-            Place.Type.NATURAL_FEATURE -> PlacesType.NATURAL_FEATURE
-            Place.Type.NEIGHBORHOOD -> PlacesType.NEIGHBORHOOD
-            Place.Type.NIGHT_CLUB -> PlacesType.NIGHT_CLUB
-            Place.Type.PAINTER -> PlacesType.PAINTER
-            Place.Type.PARK -> PlacesType.PARK
-            Place.Type.PARKING -> PlacesType.PARKING
-            Place.Type.PET_STORE -> PlacesType.PET_STORE
-            Place.Type.PHARMACY -> PlacesType.PHARMACY
-            Place.Type.PHYSIOTHERAPIST -> PlacesType.PHYSIOTHERAPIST
-            Place.Type.PLACE_OF_WORSHIP -> PlacesType.PLACE_OF_WORSHIP
-            Place.Type.PLUMBER -> PlacesType.PLUMBER
-            Place.Type.PLUS_CODE -> PlacesType.PLUS_CODE
-            Place.Type.POINT_OF_INTEREST -> PlacesType.POINT_OF_INTEREST
-            Place.Type.POLICE -> PlacesType.POLICE
-            Place.Type.POLITICAL -> PlacesType.POLITICAL
-            Place.Type.POST_BOX -> PlacesType.POST_BOX
-            Place.Type.POST_OFFICE -> PlacesType.POST_OFFICE
-            Place.Type.POSTAL_CODE_PREFIX -> PlacesType.POSTAL_CODE_PREFIX
-            Place.Type.POSTAL_CODE_SUFFIX -> PlacesType.POSTAL_CODE_SUFFIX
-            Place.Type.POSTAL_CODE -> PlacesType.POSTAL_CODE
-            Place.Type.POSTAL_TOWN -> PlacesType.POSTAL_TOWN
-            Place.Type.PREMISE -> PlacesType.PREMISE
-            Place.Type.PRIMARY_SCHOOL -> PlacesType.PRIMARY_SCHOOL
-            Place.Type.REAL_ESTATE_AGENCY -> PlacesType.REAL_ESTATE_AGENCY
-            Place.Type.RESTAURANT -> PlacesType.RESTAURANT
-            Place.Type.ROOFING_CONTRACTOR -> PlacesType.ROOFING_CONTRACTOR
-            Place.Type.ROOM -> PlacesType.ROOM
-            Place.Type.ROUTE -> PlacesType.ROUTE
-            Place.Type.RV_PARK -> PlacesType.RV_PARK
-            Place.Type.SCHOOL -> PlacesType.SCHOOL
-            Place.Type.SECONDARY_SCHOOL -> PlacesType.SECONDARY_SCHOOL
-            Place.Type.SHOE_STORE -> PlacesType.SHOE_STORE
-            Place.Type.SHOPPING_MALL -> PlacesType.SHOPPING_MALL
-            Place.Type.SPA -> PlacesType.SPA
-            Place.Type.STADIUM -> PlacesType.STADIUM
-            Place.Type.STORAGE -> PlacesType.STORAGE
-            Place.Type.STORE -> PlacesType.STORE
-            Place.Type.STREET_ADDRESS -> PlacesType.STREET_ADDRESS
-            Place.Type.STREET_NUMBER -> PlacesType.STREET_NUMBER
-            Place.Type.SUBLOCALITY_LEVEL_1 -> PlacesType.SUBLOCALITY_LEVEL_1
-            Place.Type.SUBLOCALITY_LEVEL_2 -> PlacesType.SUBLOCALITY_LEVEL_2
-            Place.Type.SUBLOCALITY_LEVEL_3 -> PlacesType.SUBLOCALITY_LEVEL_3
-            Place.Type.SUBLOCALITY_LEVEL_4 -> PlacesType.SUBLOCALITY_LEVEL_4
-            Place.Type.SUBLOCALITY_LEVEL_5 -> PlacesType.SUBLOCALITY_LEVEL_5
-            Place.Type.SUBLOCALITY -> PlacesType.SUBLOCALITY
-            Place.Type.SUBPREMISE -> PlacesType.SUBPREMISE
-            Place.Type.SUBWAY_STATION -> PlacesType.SUBWAY_STATION
-            Place.Type.SUPERMARKET -> PlacesType.SUPERMARKET
-            Place.Type.SYNAGOGUE -> PlacesType.SYNAGOGUE
-            Place.Type.TAXI_STAND -> PlacesType.TAXI_STAND
-            Place.Type.TOURIST_ATTRACTION -> PlacesType.TOURIST_ATTRACTION
-            Place.Type.TOWN_SQUARE -> PlacesType.TOWN_SQUARE
-            Place.Type.TRAIN_STATION -> PlacesType.TRAIN_STATION
-            Place.Type.TRANSIT_STATION -> PlacesType.TRANSIT_STATION
-            Place.Type.TRAVEL_AGENCY -> PlacesType.TRAVEL_AGENCY
-            Place.Type.UNIVERSITY -> PlacesType.UNIVERSITY
-            Place.Type.VETERINARY_CARE -> PlacesType.VETERINARY_CARE
-            Place.Type.ZOO -> PlacesType.ZOO
-            else -> null
-        }
     }
 }

--- a/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesManager.kt
+++ b/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesManager.kt
@@ -109,6 +109,9 @@ class GooglePlacesManager(service: GooglePlacesService, @get: Synchronized priva
         placesProcessor.start()
         placeHandler.execute { if (!placesClientCreated) {
             service.createPlacesClient()
+        }
+        if (!placesClientCreated && !Places.isInitialized()) {
+            updateApiKey(apiKey)
         } }
         updateConnected()
         placesBroadcastReceiver = service.broadcaster?.register(DEVICE_LOCATION_CHANGED) { _, _ ->
@@ -145,11 +148,15 @@ class GooglePlacesManager(service: GooglePlacesService, @get: Synchronized priva
     }
 
     private fun updateConnected() {
+        if (Places.isInitialized()) {
             status = SourceStatusListener.Status.CONNECTED
+        }
     }
+
     private fun initializePlacesClient() {
         try {
             Places.initialize(service.applicationContext, apiKey)
+            updateConnected()
         } catch (ex: Exception) {
             logger.error("Exception while initializing places API", ex)
             service.internalError.set(true)

--- a/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesManager.kt
+++ b/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesManager.kt
@@ -216,11 +216,10 @@ class GooglePlacesManager(service: GooglePlacesService, @get: Synchronized priva
                 time = currentTime
                 timeReceived = currentTime
                 if (types != null) {
-                    val size = types.size
-                    if (size >= 1) placeType1 = types[0]
-                    if (size >= 2) placeType2 = types[1]
-                    if (size >= 3) placeType3 = types[2]
-                    if (size >= 4) placeType4 = types[3]
+                    placeType1 = types.getOrNull(0)
+                    placeType2 = types.getOrNull(1)
+                    placeType3 = types.getOrNull(2)
+                    placeType4 = types.getOrNull(3)
                 }
                 this.likelihood = likelihood.likelihood
                 fromBroadcast = fromBroadcastRegistration

--- a/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesManager.kt
+++ b/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesManager.kt
@@ -109,7 +109,7 @@ class GooglePlacesManager(service: GooglePlacesService, @get: Synchronized priva
         status = SourceStatusListener.Status.READY
         placesProcessor.start()
         placeHandler.execute { if (!placesClientCreated) createPlacesClient() }
-        service.broadcaster.register(DEVICE_LOCATION_CHANGED) { _, _ ->
+        placesBroadcastReceiver = service.broadcaster?.register(DEVICE_LOCATION_CHANGED) { _, _ ->
             if (placesClientCreated) {
                 placeHandler.execute {
                     state.fromBroadcast.set(true)
@@ -322,6 +322,7 @@ class GooglePlacesManager(service: GooglePlacesService, @get: Synchronized priva
                     logger.warn("Places receiver already unregistered in broadcast")
                 }
                 placesBroadcastReceiver = null
+                Places.deinitialize()
                 placesProcessor.close()
             }
     }

--- a/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesService.kt
+++ b/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesService.kt
@@ -37,7 +37,9 @@ import kotlin.math.pow
 class GooglePlacesService: SourceService<GooglePlacesState>() {
     private val apiKey: ChangeRunner<String> = ChangeRunner(GOOGLE_PLACES_API_KEY_DEFAULT)
     lateinit var preferences: SharedPreferences
-    val broadcaster = LocalBroadcastManager.getInstance(this)
+    private var _broadcaster: LocalBroadcastManager? = null
+    val broadcaster: LocalBroadcastManager?
+        get() = _broadcaster
     private lateinit var placeHandler: SafeHandler
 
     val internalError = AtomicBoolean(false)
@@ -52,6 +54,7 @@ class GooglePlacesService: SourceService<GooglePlacesState>() {
             start()
         }
         preferences = getSharedPreferences(GooglePlacesService::class.java.name, Context.MODE_PRIVATE)
+        _broadcaster = LocalBroadcastManager.getInstance(this)
     }
 
     override fun configureSourceManager(manager: SourceManager<GooglePlacesState>, config: SingleRadarConfiguration) {
@@ -89,7 +92,7 @@ class GooglePlacesService: SourceService<GooglePlacesState>() {
                 val currentManager = sourceManager
                 (currentManager as? GooglePlacesManager)?.reScan()
                 if (currentManager == null) {
-                    broadcaster.send(SOURCE_STATUS_CHANGED) {
+                    broadcaster?.send(SOURCE_STATUS_CHANGED) {
                         putExtra(SOURCE_STATUS_CHANGED, SourceStatusListener.Status.DISCONNECTED.ordinal)
                         putExtra(SOURCE_SERVICE_CLASS, this@GooglePlacesService.javaClass.name)
                     }

--- a/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesService.kt
+++ b/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesService.kt
@@ -38,10 +38,9 @@ import kotlin.math.pow
 class GooglePlacesService: SourceService<GooglePlacesState>() {
     private val apiKey: ChangeRunner<String> = ChangeRunner()
     lateinit var preferences: SharedPreferences
-    private var _broadcaster: LocalBroadcastManager? = null
     val placesClientCreated = AtomicBoolean(false)
-    val broadcaster: LocalBroadcastManager?
-        get() = _broadcaster
+    var broadcaster: LocalBroadcastManager? = null
+        private set
     private lateinit var placeHandler: SafeHandler
     var placesClient: PlacesClient? = null
         @Synchronized get() = if (placesClientCreated.get()) field else null
@@ -58,7 +57,7 @@ class GooglePlacesService: SourceService<GooglePlacesState>() {
             start()
         }
         preferences = getSharedPreferences(GooglePlacesService::class.java.name, Context.MODE_PRIVATE)
-        _broadcaster = LocalBroadcastManager.getInstance(this)
+        broadcaster = LocalBroadcastManager.getInstance(this)
     }
 
     override fun configureSourceManager(manager: SourceManager<GooglePlacesState>, config: SingleRadarConfiguration) {

--- a/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesService.kt
+++ b/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesService.kt
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.pow
 
 class GooglePlacesService: SourceService<GooglePlacesState>() {
-    private val apiKey: ChangeRunner<String> = ChangeRunner(GOOGLE_PLACES_API_KEY_DEFAULT)
+    private val apiKey: ChangeRunner<String> = ChangeRunner()
     lateinit var preferences: SharedPreferences
     private var _broadcaster: LocalBroadcastManager? = null
     val placesClientCreated = AtomicBoolean(false)
@@ -123,7 +123,7 @@ class GooglePlacesService: SourceService<GooglePlacesState>() {
     override val defaultState: GooglePlacesState
         get() = GooglePlacesState()
 
-    override fun createSourceManager(): GooglePlacesManager = GooglePlacesManager(this, apiKey.lastResult, placeHandler)
+    override fun createSourceManager(): GooglePlacesManager = GooglePlacesManager(this, GOOGLE_PLACES_API_KEY_DEFAULT, placeHandler)
 
     override val isBluetoothConnectionRequired: Boolean = false
 

--- a/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesState.kt
+++ b/plugins/radar-android-google-places/src/main/java/org.radarbase.passive.google.places/GooglePlacesState.kt
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class GooglePlacesState : BaseSourceState() {
 
-    val placesClientCreated = AtomicBoolean(false)
     val fromBroadcast = AtomicBoolean(false)
     val shouldFetchPlaceId = AtomicBoolean(false)
     val shouldFetchAdditionalInfo = AtomicBoolean(false)


### PR DESCRIPTION
The Google Places plugin is consuming too many resources, which is affecting performance and causing `OutOfMemoryException` errors.

In the first attached screenshot, the PlacesClient used in the Places API spawns multiple threads internally (nearly 10) every time the plugin is reloaded and never collected again, resulting in excessive thread overhead.

In the second screenshot, multiple instances of GooglePlacesManager are present, which are not being garbage collected.

<br>
<img width="928" alt="GooglePlaces" src="https://github.com/RADAR-base/radar-commons-android/assets/98681758/99dfc457-c9e4-47ad-88bd-9b2f5b5d6785">
<img width="959" alt="PlacesManager" src="https://github.com/RADAR-base/radar-commons-android/assets/98681758/e613766c-51c0-4157-a588-64afbc119d02">
