### PR TITLE
Improvements for firebase config fetching

### DIFF
--- a/radar-commons-android/src/main/java/org/radarbase/android/config/FirebaseRemoteConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/config/FirebaseRemoteConfiguration.kt
@@ -70,6 +70,7 @@ class FirebaseRemoteConfiguration(private val context: Context, inDevelopmentMod
             // activated before newly fetched values are returned.
             firebase.activate()
                     .addOnSuccessListener {
+                        lastFetch = System.currentTimeMillis()
                         cache = firebase.getKeysByPrefix("")
                                 .mapNotNull { key ->
                                     firebase.getValue(key).asString()
@@ -91,11 +92,11 @@ class FirebaseRemoteConfiguration(private val context: Context, inDevelopmentMod
      * @param maxCacheAge seconds
      * @return fetch task or null status is [RadarConfiguration.RemoteConfigStatus.UNAVAILABLE].
      */
-    override fun doFetch(maxCacheAge: Long) {
+    override fun doFetch(maxCacheAgeMillis: Long) {
         if (status == RadarConfiguration.RemoteConfigStatus.UNAVAILABLE) {
             return
         }
-        val task = firebase.fetch(maxCacheAge)
+        val task = firebase.fetch(maxCacheAgeMillis / 1000L)
         synchronized(this) {
             status = RadarConfiguration.RemoteConfigStatus.FETCHING
             task.addOnSuccessListener(onFetchCompleteHandler)

--- a/radar-commons-android/src/main/java/org/radarbase/android/config/RemoteConfig.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/config/RemoteConfig.kt
@@ -10,7 +10,7 @@ interface RemoteConfig {
     var lastFetch: Long
     val cache: Map<String, String>
 
-    fun doFetch(maxCacheAge: Long)
+    fun doFetch(maxCacheAgeMillis: Long)
 
     fun fetch(maxCacheAge: Long) {
         if (lastFetch + maxCacheAge < System.currentTimeMillis()) {


### PR DESCRIPTION
- Updated the code in `remoteConfigs::fetch` to use seconds, as `firebase.fetch` takes the number of seconds as a parameter instead of ms.
- Updating the lastFetch time in FirebaseRemoteConfiguration when data is fetched.