### PR TITLE
Updated radar-commons-android to Target SDK 34 (Android 14) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ allprojects {
     version = "$project_version"
     group = 'org.radarbase'
 
-    ext.versionCode = 52
+    ext.versionCode = 54
 }
 
 subprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.defaults.buildfeatures.buildconfig=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-project_version=1.2.5
+project_version=1.4.1-SNAPSHOT
 
 java_version=17
 kotlin_version=1.9.23

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -4,7 +4,7 @@ android {
 
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode versionCode
         versionName version
     }

--- a/plugins/radar-android-google-activity/src/main/java/org/radarbase/passive/google/activity/GoogleActivityManager.kt
+++ b/plugins/radar-android-google-activity/src/main/java/org/radarbase/passive/google/activity/GoogleActivityManager.kt
@@ -70,7 +70,7 @@ class GoogleActivityManager(context: GoogleActivityService) : AbstractSourceMana
     private fun registerActivityTransitionReceiver() {
         val filter = IntentFilter(ACTION_ACTIVITY_UPDATE)
         ContextCompat.registerReceiver(service, activityTransitionReceiver, filter,
-            ContextCompat.RECEIVER_EXPORTED
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
         logger.info("Registered activity transition receiver.")
     }
@@ -119,7 +119,9 @@ class GoogleActivityManager(context: GoogleActivityService) : AbstractSourceMana
     }
 
     private fun createActivityPendingIntent(): PendingIntent {
-        val intent = Intent(ACTION_ACTIVITY_UPDATE)
+        val intent = Intent(ACTION_ACTIVITY_UPDATE).apply {
+            `package` = service.packageName
+        }
         logger.info("Activity pending intent created")
         return PendingIntent.getBroadcast(service, ACTIVITY_UPDATE_REQUEST_CODE, intent,
             PendingIntent.FLAG_CANCEL_CURRENT.toPendingIntentFlag(true)

--- a/plugins/radar-android-google-activity/src/main/java/org/radarbase/passive/google/activity/GoogleActivityManager.kt
+++ b/plugins/radar-android-google-activity/src/main/java/org/radarbase/passive/google/activity/GoogleActivityManager.kt
@@ -69,7 +69,9 @@ class GoogleActivityManager(context: GoogleActivityService) : AbstractSourceMana
 
     private fun registerActivityTransitionReceiver() {
         val filter = IntentFilter(ACTION_ACTIVITY_UPDATE)
-        service.registerReceiver(activityTransitionReceiver, filter)
+        ContextCompat.registerReceiver(service, activityTransitionReceiver, filter,
+            ContextCompat.RECEIVER_EXPORTED
+        )
         logger.info("Registered activity transition receiver.")
     }
 

--- a/plugins/radar-android-google-sleep/src/main/java/org.radarbase.passive.google.sleep/GoogleSleepManager.kt
+++ b/plugins/radar-android-google-sleep/src/main/java/org.radarbase.passive.google.sleep/GoogleSleepManager.kt
@@ -19,9 +19,13 @@ package org.radarbase.passive.google.sleep
 import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES
 import android.os.Process
 import androidx.core.content.ContextCompat
 import com.google.android.gms.location.ActivityRecognition
@@ -69,7 +73,9 @@ class GoogleSleepManager(context: GoogleSleepService) : AbstractSourceManager<Go
 
     private fun registerSleepReceiver() {
         val filter = IntentFilter(ACTION_SLEEP_DATA)
-        service.registerReceiver(sleepBroadcastReceiver, filter)
+        ContextCompat.registerReceiver(service, sleepBroadcastReceiver, filter,
+            ContextCompat.RECEIVER_EXPORTED
+        )
         logger.info("registering for the sleep receiver.")
     }
 

--- a/plugins/radar-android-google-sleep/src/main/java/org.radarbase.passive.google.sleep/GoogleSleepManager.kt
+++ b/plugins/radar-android-google-sleep/src/main/java/org.radarbase.passive.google.sleep/GoogleSleepManager.kt
@@ -74,7 +74,7 @@ class GoogleSleepManager(context: GoogleSleepService) : AbstractSourceManager<Go
     private fun registerSleepReceiver() {
         val filter = IntentFilter(ACTION_SLEEP_DATA)
         ContextCompat.registerReceiver(service, sleepBroadcastReceiver, filter,
-            ContextCompat.RECEIVER_EXPORTED
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
         logger.info("registering for the sleep receiver.")
     }
@@ -130,7 +130,9 @@ class GoogleSleepManager(context: GoogleSleepService) : AbstractSourceManager<Go
     }
 
     private fun createSleepPendingIntent(): PendingIntent {
-        val intent = Intent(ACTION_SLEEP_DATA)
+        val intent = Intent(ACTION_SLEEP_DATA).apply {
+            `package` = service.packageName
+        }
         logger.info("Sleep pending intent created")
         return PendingIntent.getBroadcast(service, SLEEP_DATA_REQUEST_CODE, intent,
             PendingIntent.FLAG_CANCEL_CURRENT.toPendingIntentFlag(true))

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -28,7 +28,6 @@ import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
 import android.os.*
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES
@@ -64,7 +63,6 @@ import org.radarcns.kafka.ObservationKey
 import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.collections.HashSet
 
 abstract class RadarService : LifecycleService(), ServerStatusListener, LoginListener {
     private var configurationUpdateFuture: SafeHandler.HandlerFuture? = null
@@ -237,12 +235,11 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         } else {
 
             /**
-             * API 34+ (Android 14+): Adding DATA_SYNC and SPECIAL_USE types
+             * API 34+ (Android 14+): Adding DATA_SYNC type
              * Currently this is not explicitly checking for android 14+ version.
              * This need to be modified it in future when setting new targetSdkVersion
              */
             startForeground(1, createForegroundNotification(),
-                FOREGROUND_SERVICE_TYPE_SPECIAL_USE or
                         FOREGROUND_SERVICE_TYPE_DATA_SYNC
             )
         }
@@ -278,9 +275,6 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         }
 
         if (fgsTypePermissions.isNotEmpty()) {
-            if (SDK_INT >= UPSIDE_DOWN_CAKE) {
-                fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
-            }
 
             fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_DATA_SYNC)
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -237,7 +237,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         } else {
 
             /**
-             * API 34+ (Android 14+): Adding HEALTH and SPECIAL_USE types
+             * API 34+ (Android 14+): Adding DATA_SYNC and SPECIAL_USE types
              * Currently this is not explicitly checking for android 14+ version.
              * This need to be modified it in future when setting new targetSdkVersion
              */
@@ -284,7 +284,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
 
             fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_DATA_SYNC)
 
-            val combinedFgsType = fgsTypePermissions.reduce { acc, type -> acc or type }
+            val combinedFgsType: Int = fgsTypePermissions.reduce { acc, type -> acc or type }
 
             startForeground(
                 1, createForegroundNotification(),

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/Extensions.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/Extensions.kt
@@ -8,6 +8,7 @@ fun String.takeTrimmedIfNotEmpty(): String? = trim { it <= ' ' }
             .takeUnless(String::isEmpty)
 
 fun Int.toPendingIntentFlag(mutable: Boolean = false) = this or when {
+    mutable && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT
     mutable && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> PendingIntent.FLAG_MUTABLE
     !mutable -> PendingIntent.FLAG_IMMUTABLE
     else -> 0

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/Extensions.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/Extensions.kt
@@ -7,6 +7,23 @@ import android.os.Build
 fun String.takeTrimmedIfNotEmpty(): String? = trim { it <= ' ' }
             .takeUnless(String::isEmpty)
 
+/**
+ * Converts an integer to a PendingIntent flag with appropriate mutability settings.
+ *
+ * Android 14 (API level 34) introduces stricter security requirements for `PendingIntents`.
+ * - By default, `PendingIntents` should be immutable (`FLAG_IMMUTABLE`) unless explicitly required to be mutable.
+ * - Using the mutable flag without necessity may lead to security vulnerabilities, as mutable `PendingIntents`
+ *   can be modified by other apps if granted.
+ *
+ * This function checks the Android version to set flags appropriately:
+ * - For API level 34 and above (`UPSIDE_DOWN_CAKE`), includes `FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT` to bypass the
+ *   implicit intent restriction if `mutable` is true.
+ * - For API level 31 (Android 12, `S`) to API level 33, `FLAG_MUTABLE` is used when `mutable` is true.
+ * - For any other case or if `mutable` is false, the flag defaults to `FLAG_IMMUTABLE`.
+ *
+ * @param mutable Determines if the `PendingIntent` needs to be mutable (default: false).
+ * @return The calculated `PendingIntent` flag with the correct mutability based on API level.
+ */
 fun Int.toPendingIntentFlag(mutable: Boolean = false) = this or when {
     mutable && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT
     mutable && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> PendingIntent.FLAG_MUTABLE
@@ -14,7 +31,6 @@ fun Int.toPendingIntentFlag(mutable: Boolean = false) = this or when {
     else -> 0
 }
 
-@Suppress("UNCHECKED_CAST")
 inline fun <reified T> Context.applySystemService(type: String, callback: (T) -> Boolean): Boolean? {
     return (getSystemService(type) as T?)?.let(callback)
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/OfflineProcessor.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/OfflineProcessor.kt
@@ -81,7 +81,9 @@ class OfflineProcessor(
         this.alarmManager = context.getSystemService(ALARM_SERVICE) as AlarmManager
 
         handler = config.handlerReference.acquire()
-        val intent = Intent(config.requestName)
+        val intent = Intent(config.requestName).apply {
+            `package` = context.packageName
+        }
         pendingIntent = PendingIntent.getBroadcast(
             context,
             requireNotNull(config.requestCode) { "Cannot start processor without request code" },
@@ -109,7 +111,7 @@ class OfflineProcessor(
                 context,
                 this.receiver,
                 IntentFilter(requestName),
-                RECEIVER_EXPORTED
+                ContextCompat.RECEIVER_NOT_EXPORTED
             )
             schedule()
             initializer?.let { it() }

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/OfflineProcessor.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/OfflineProcessor.kt
@@ -29,6 +29,8 @@ import android.os.Debug
 import android.os.PowerManager
 import android.os.Process.THREAD_PRIORITY_BACKGROUND
 import android.os.SystemClock
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_EXPORTED
 import org.radarbase.util.CountedReference
 import org.slf4j.LoggerFactory
 import java.io.Closeable
@@ -103,7 +105,12 @@ class OfflineProcessor(
         }
         handler.execute {
             didStart = true
-            context.registerReceiver(this.receiver, IntentFilter(requestName))
+            ContextCompat.registerReceiver(
+                context,
+                this.receiver,
+                IntentFilter(requestName),
+                RECEIVER_EXPORTED
+            )
             schedule()
             initializer?.let { it() }
         }


### PR DESCRIPTION
* Updated **RadarService** to accommodate new foreground service types and invoke `startForeground` after all required permissions for the foreground service are granted.
* Updated the broadcast receiver and implicit pending intent following the Android 14 behavior change documentation guidelines.
