### PR TITLE
Added support for collecting app metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_android_gradle_plugin_version"
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version")
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
+        classpath "androidx.room:room-gradle-plugin:$room_version"
     }
 }
 
@@ -59,6 +60,7 @@ subprojects {
     apply plugin: 'com.android.library'
     apply plugin: 'kotlin-android'
     apply plugin: 'idea'
+    apply plugin: 'kotlin-kapt'
 
 //---------------------------------------------------------------------------//
 // Sources and classpath configurations                                      //

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.defaults.buildfeatures.buildconfig=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-project_version=1.2.5
+project_version=1.4.3-SNAPSHOT
 
 java_version=17
 kotlin_version=1.9.23
@@ -36,9 +36,11 @@ dokka_android_gradle_plugin_version=0.9.18
 dokka_version=1.9.20
 publish_plugin_version=2.0.0
 versions_plugin_version=0.51.0
+room_version=2.6.1
+paging_version=3.3.6
 
-radar_commons_version=1.1.2
-radar_schemas_commons_version=0.8.11
+radar_commons_version=1.1.3-SNAPSHOT
+radar_schemas_commons_version=0.8.11-SNAPSHOT
 
 radar_faros_sdk_version=0.1.0
 

--- a/plugins/radar-android-application-status/README.md
+++ b/plugins/radar-android-application-status/README.md
@@ -22,20 +22,27 @@ To activate this plugin, add the provider `application_status` to the Firebase R
 
 This plugin takes the following Firebase configuration parameters:
 
-| Name | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `ntp_server` | string | `<empty>` | NTP server to synchronize time with. If empty, time is not synchronized and the `application_external_time` topic will not receive data. |
-| `application_status_update_rate` | int (seconds) | `300` = 5 minutes | Rate at which to send data for all application topics. |
-| `application_send_ip` | boolean | `false` | Whether to send the device IP address with the server status. |
-| `application_time_zone_update_rate` | int (seconds) | `86400` = 1 day | How often to send the current time zone. Set to `0` to disable. |
+| Name                                           | Type          | Default                 | Description                                                                                                                                              |
+|------------------------------------------------|---------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ntp_server`                                   | string        | `<empty>`               | NTP server to synchronize time with. If empty, time is not synchronized and the `application_external_time` topic will not receive data.                 |
+| `application_status_update_rate`               | int (seconds) | `300` = 5 minutes       | Rate at which to send data for all application topics.                                                                                                   |
+| `application_send_ip`                          | boolean       | `false`                 | Whether to send the device IP address with the server status.                                                                                            |
+| `application_time_zone_update_rate`            | int (seconds) | `86400` = 1 day         | How often to send the current time zone. Set to `0` to disable.                                                                                          |
+| `application_metrics_verification_update_rate` | int (seconds) | `300` = 5 minutes       | Defines the interval for verifying that records older than application_metrics_retention_time are not present. Set to 0 to disable.                      |
+| `application_metrics_buffer_size`              | int (count)   | `100`                   | Specifies the number of records to keep in the buffer before adding them to the database. Storing records in batches significantly improves performance. |
+| `application_metrics_retention_time`           | int (seconds) | `7*86400` = 7 day       | Determines how long application metrics are retained in the database. Records older than this value are automatically deleted.                           |
+| `application_metrics_data_retention_count`     | int (seconds) | `10000` = 10000 records | Specifies the maximum number of messages to retain for application metrics in the database. When this limit is exceeded, older messages are deleted.     |
 
 This plugin produces data for the following topics: (types starts with `org.radarcns.monitor.application` prefix)
 
-| Topic | Type | Description |
-| ----- | ---- | ----------- |
-| `application_external_time` | `ApplicationExternalTime` | External NTP time. Requires `ntp_server` parameter to be set. |
-| `application_record_counts` | `ApplicationRecordCounts` | Number of records sent and in queue. |
-| `application_uptime` | `ApplicationUptime` | Time since the device booted. |
-| `application_server_status` | `ApplicationServerStatus` | Server connection status. |
-| `application_time_zone` | `ApplicationTimeZone` | Application time zone. Data is only sent on updates. |
-| `application_device_info` | `ApplicationDeviceInfo` | Device information. Data is only sent on updates. |
+| Topic                            | Type                          | Description                                                                                                                                                                        |
+|----------------------------------|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `application_external_time`      | `ApplicationExternalTime`     | External NTP time. Requires `ntp_server` parameter to be set.                                                                                                                      |
+| `application_record_counts`      | `ApplicationRecordCounts`     | Number of records sent and in queue.                                                                                                                                               |
+| `application_uptime`             | `ApplicationUptime`           | Time since the device booted.                                                                                                                                                      |
+| `application_server_status`      | `ApplicationServerStatus`     | Server connection status.                                                                                                                                                          |
+| `application_time_zone`          | `ApplicationTimeZone`         | Application time zone. Data is only sent on updates.                                                                                                                               |
+| `application_device_info`        | `ApplicationDeviceInfo`       | Device information. Data is only sent on updates.                                                                                                                                  |
+| `application_network_status`     | `ApplicationNetworkStatus`    | Represents the network connectivity status of an application, indicating whether it is connected to the internet and, if so, whether the connection is via Wi-Fi or cellular data. |
+| `application_plugin_status`      | `ApplicationPluginStatus`     | Represents the status of a plugin, indicating its current connection state.                                                                                                        |
+| `application_topic_records_sent` | `ApplicationTopicRecordsSent` | Number of records sent for the topic since the last upload                                                                                                                         |

--- a/plugins/radar-android-application-status/build.gradle
+++ b/plugins/radar-android-application-status/build.gradle
@@ -13,9 +13,34 @@ description = "Application statistics plugin for RADAR passive remote monitoring
 // Sources and classpath configurations                                      //
 //---------------------------------------------------------------------------//
 
+android {
+    buildFeatures {
+        viewBinding true
+    }
+}
+
 dependencies {
     api project(":radar-commons-android")
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:$localbroadcastmanager_version"
+    implementation "androidx.appcompat:appcompat:$appcompat_version"
+    implementation "com.google.android.material:material:$material_version"
+    implementation "androidx.activity:activity:1.9.0"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
+    implementation "androidx.legacy:legacy-support-v4:$legacy_support_version"
+    implementation 'androidx.fragment:fragment-ktx:1.8.1'
+    implementation "androidx.paging:paging-runtime:$paging_version"
+    runtimeOnly 'androidx.recyclerview:recyclerview:1.3.2'
+
+    implementation "androidx.room:room-runtime:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-ktx:$room_version" // For Kotlin Coroutines support
+
+    implementation "androidx.room:room-paging:2.6.1"
+}
+
+afterEvaluate {
+    tasks["dokkaJavadoc"].dependsOn(tasks.getByName("kaptReleaseKotlin"), tasks.getByName("kaptDebugKotlin"))
 }
 
 apply from: "$rootDir/gradle/publishing.gradle"
+apply plugin: 'org.jetbrains.kotlin.android'

--- a/plugins/radar-android-application-status/src/main/AndroidManifest.xml
+++ b/plugins/radar-android-application-status/src/main/AndroidManifest.xml
@@ -2,8 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
-        <service android:name=".ApplicationStatusService"
-            android:exported="false"
-            android:description="@string/application_status_description" />
+        <activity
+            android:name=".ui.ApplicationMetricsActivity"
+            android:exported="false" />
+
+        <service
+            android:name=".ApplicationStatusService"
+            android:description="@string/application_status_description"
+            android:exported="false" />
     </application>
+
 </manifest>

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationState.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationState.kt
@@ -41,6 +41,7 @@ class ApplicationState : BaseSourceState() {
     var recordsSent = 0L
         private set
 
+    val metricsCountPerTopic: MutableMap<String, Long> = ConcurrentHashMap()
     val cachedRecords: MutableMap<String, Long> = ConcurrentHashMap()
     val recordsSentPerTopic: MutableMap<String, Long> = ConcurrentHashMap()
     private val sourceStatusBuffer: MutableList<SourceStatusLog> = mutableListOf()

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationState.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationState.kt
@@ -16,11 +16,23 @@
 
 package org.radarbase.monitor.application
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.radarbase.android.kafka.ServerStatus
 import org.radarbase.android.source.BaseSourceState
+import org.radarbase.android.storage.entity.NetworkStatusLog
+import org.radarbase.android.storage.entity.SourceStatusLog
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 class ApplicationState : BaseSourceState() {
+
+    private val sourceStatusMutex: Mutex = Mutex()
+    private val networkStatusMutex: Mutex = Mutex()
+
+    val sourceStatusBufferCount: AtomicInteger = AtomicInteger(0)
+    val networkStatusBufferCount: AtomicInteger = AtomicInteger(0)
+
     @set:Synchronized
     var serverStatus: ServerStatus? = null
         @Synchronized get() = field ?: ServerStatus.DISCONNECTED
@@ -30,6 +42,39 @@ class ApplicationState : BaseSourceState() {
         private set
 
     val cachedRecords: MutableMap<String, Long> = ConcurrentHashMap()
+    val recordsSentPerTopic: MutableMap<String, Long> = ConcurrentHashMap()
+    private val sourceStatusBuffer: MutableList<SourceStatusLog> = mutableListOf()
+    private val networkStatusBuffer: MutableList<NetworkStatusLog> = mutableListOf()
+
+    suspend fun addSourceStatus(status: SourceStatusLog) {
+        sourceStatusMutex.withLock {
+            sourceStatusBuffer.add(status)
+        }
+    }
+
+    suspend fun clearSourceStatuses() {
+        sourceStatusMutex.withLock {
+            sourceStatusBuffer.clear()
+        }
+    }
+
+    suspend fun clearNetworkStatuses() {
+        networkStatusMutex.withLock {
+            networkStatusBuffer.clear()
+        }
+    }
+
+    suspend fun getSourceStatuses(): List<SourceStatusLog> = sourceStatusMutex.withLock {
+        sourceStatusBuffer
+    }
+    
+    suspend fun addNetworkStatus(status: NetworkStatusLog) = networkStatusMutex.withLock {
+        networkStatusBuffer.add(status)
+    }
+    
+    suspend fun getNetworkStatus(): List<NetworkStatusLog> = networkStatusMutex.withLock {
+        networkStatusBuffer
+    }
 
     @Synchronized
     fun addRecordsSent(nRecords: Long) {

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationState.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationState.kt
@@ -29,6 +29,8 @@ class ApplicationState : BaseSourceState() {
 
     private val sourceStatusMutex: Mutex = Mutex()
     private val networkStatusMutex: Mutex = Mutex()
+    var uiManager: UserInterfaceManager? = null
+    var uiStatusUpdateRate: Long = 60
 
     val sourceStatusBufferCount: AtomicInteger = AtomicInteger(0)
     val networkStatusBufferCount: AtomicInteger = AtomicInteger(0)
@@ -80,5 +82,10 @@ class ApplicationState : BaseSourceState() {
     @Synchronized
     fun addRecordsSent(nRecords: Long) {
         recordsSent += nRecords
+    }
+
+    interface UserInterfaceManager {
+        fun sendSourceStatus()
+        fun sendNetworkStatus()
     }
 }

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusProvider.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusProvider.kt
@@ -16,9 +16,11 @@
 
 package org.radarbase.monitor.application
 
+import android.content.Intent
 import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.monitor.application.ui.ApplicationMetricsActivity
 
 open class ApplicationStatusProvider(radarService: RadarService) : SourceProvider<ApplicationState>(radarService) {
     override val description: String?
@@ -46,4 +48,9 @@ open class ApplicationStatusProvider(radarService: RadarService) : SourceProvide
     override val sourceModel: String = "pRMT"
 
     override val version: String = BuildConfig.VERSION_NAME
+
+    override val actions: List<Action>
+        get() = listOf(Action(radarService.getString(R.string.start_app_metrics_activity)){
+            startActivity(Intent(this, ApplicationMetricsActivity::class.java))
+        })
 }

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusService.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusService.kt
@@ -38,6 +38,7 @@ class ApplicationStatusService : SourceService<ApplicationState>() {
         manager.metricsBatchSize = config.getLong(APPLICATION_METRICS_BATCH_SIZE, APPLICATION_METRICS_BATCH_SIZE_DEFAULT)
         manager.metricsRetentionSize = config.getLong(APPLICATION_METRICS_DATA_RETENTION_COUNT, APPLICATION_METRICS_DATA_RETENTION_COUNT_DEFAULT)
         manager.metricsRetentionTime = config.getLong(APPLICATION_METRICS_RETENTION_TIME, APPLICATION_METRICS_RETENTION_TIME_DEFAULT)
+        manager.uiStatusUpdateRate = config.getLong(APPLICATION_PLUGIN_UI_COUNT_UPDATE_RATE, APPLICATION_PLUGIN_UI_COUNT_UPDATE_RATE_DEFAULT)
     }
 
     companion object {
@@ -47,9 +48,11 @@ class ApplicationStatusService : SourceService<ApplicationState>() {
         private const val APPLICATION_METRICS_BATCH_SIZE = "application_metrics_buffer_size"
         private const val APPLICATION_METRICS_RETENTION_TIME = "application_metrics_retention_time_value"
         private const val APPLICATION_METRICS_DATA_RETENTION_COUNT = "application_metrics_data_retention_count"
-        private const val APPLICATION_METRICS_BATCH_SIZE_DEFAULT = 100L
+        private const val APPLICATION_METRICS_BATCH_SIZE_DEFAULT = 5L
         private const val APPLICATION_METRICS_RETENTION_TIME_DEFAULT = 7 * 86400L // seconds == 1 day
         private const val APPLICATION_METRICS_DATA_RETENTION_COUNT_DEFAULT = 10000L // 10,000 counts per topic
+        private const val APPLICATION_PLUGIN_UI_COUNT_UPDATE_RATE = "application_plugin_ui_count_update_rate"
+        private const val APPLICATION_PLUGIN_UI_COUNT_UPDATE_RATE_DEFAULT = 60L // 1 minute
         private const val SEND_IP = "application_send_ip"
         internal const val UPDATE_RATE_DEFAULT = 300L // seconds == 5 minutes
         internal const val VERIFICATION_UPDATE_RATE_DEFAULT = 300L // seconds == 5 minutes

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusService.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusService.kt
@@ -36,6 +36,8 @@ class ApplicationStatusService : SourceService<ApplicationState>() {
         manager.ntpServer = config.optString(NTP_SERVER_CONFIG)
         manager.isProcessingIp = config.getBoolean(SEND_IP, false)
         manager.metricsBatchSize = config.getLong(APPLICATION_METRICS_BATCH_SIZE, APPLICATION_METRICS_BATCH_SIZE_DEFAULT)
+        manager.metricsRetentionSize = config.getLong(APPLICATION_METRICS_DATA_RETENTION_COUNT, APPLICATION_METRICS_DATA_RETENTION_COUNT_DEFAULT)
+        manager.metricsRetentionTime = config.getLong(APPLICATION_METRICS_RETENTION_TIME, APPLICATION_METRICS_RETENTION_TIME_DEFAULT)
     }
 
     companion object {
@@ -43,11 +45,11 @@ class ApplicationStatusService : SourceService<ApplicationState>() {
         private const val TZ_UPDATE_RATE = "application_time_zone_update_rate"
         private const val VERIFICATION_UPDATE_RATE = "application_time_zone_update_rate"
         private const val APPLICATION_METRICS_BATCH_SIZE = "application_metrics_buffer_size"
-        private const val APPLICATION_METRICS_RETENTION_TIME_VALUE = "application_metrics_retention_time_value"
-        private const val APPLICATION_METRICS_RETENTION_TIME_UNIT = "application_metrics_retention_time_unit"
+        private const val APPLICATION_METRICS_RETENTION_TIME = "application_metrics_retention_time_value"
+        private const val APPLICATION_METRICS_DATA_RETENTION_COUNT = "application_metrics_data_retention_count"
         private const val APPLICATION_METRICS_BATCH_SIZE_DEFAULT = 100L
-        private const val APPLICATION_METRICS_RETENTION_TIME_VALUE_DEFAULT = 7 * 86400
-        private const val APPLICATION_METRICS_RETENTION_TIME_UNIT_DEFAULT = "day"
+        private const val APPLICATION_METRICS_RETENTION_TIME_DEFAULT = 7 * 86400L // seconds == 1 day
+        private const val APPLICATION_METRICS_DATA_RETENTION_COUNT_DEFAULT = 10000L // 10,000 counts per topic
         private const val SEND_IP = "application_send_ip"
         internal const val UPDATE_RATE_DEFAULT = 300L // seconds == 5 minutes
         internal const val VERIFICATION_UPDATE_RATE_DEFAULT = 300L // seconds == 5 minutes

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusService.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusService.kt
@@ -44,11 +44,11 @@ class ApplicationStatusService : SourceService<ApplicationState>() {
     companion object {
         private const val UPDATE_RATE = "application_status_update_rate"
         private const val TZ_UPDATE_RATE = "application_time_zone_update_rate"
-        private const val VERIFICATION_UPDATE_RATE = "application_time_zone_update_rate"
+        private const val VERIFICATION_UPDATE_RATE = "application_metrics_verification_update_rate"
         private const val APPLICATION_METRICS_BATCH_SIZE = "application_metrics_buffer_size"
-        private const val APPLICATION_METRICS_RETENTION_TIME = "application_metrics_retention_time_value"
+        private const val APPLICATION_METRICS_RETENTION_TIME = "application_metrics_retention_time"
         private const val APPLICATION_METRICS_DATA_RETENTION_COUNT = "application_metrics_data_retention_count"
-        private const val APPLICATION_METRICS_BATCH_SIZE_DEFAULT = 5L
+        private const val APPLICATION_METRICS_BATCH_SIZE_DEFAULT = 100L
         private const val APPLICATION_METRICS_RETENTION_TIME_DEFAULT = 7 * 86400L // seconds == 1 day
         private const val APPLICATION_METRICS_DATA_RETENTION_COUNT_DEFAULT = 10000L // 10,000 counts per topic
         private const val APPLICATION_PLUGIN_UI_COUNT_UPDATE_RATE = "application_plugin_ui_count_update_rate"

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusService.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ApplicationStatusService.kt
@@ -32,15 +32,25 @@ class ApplicationStatusService : SourceService<ApplicationState>() {
         manager as ApplicationStatusManager
         manager.setApplicationStatusUpdateRate(config.getLong(UPDATE_RATE, UPDATE_RATE_DEFAULT), TimeUnit.SECONDS)
         manager.setTzUpdateRate(config.getLong(TZ_UPDATE_RATE, TZ_UPDATE_RATE_DEFAULT), TimeUnit.SECONDS)
+        manager.setVerificationUpdateRate(config.getLong(VERIFICATION_UPDATE_RATE, VERIFICATION_UPDATE_RATE_DEFAULT), TimeUnit.SECONDS)
         manager.ntpServer = config.optString(NTP_SERVER_CONFIG)
         manager.isProcessingIp = config.getBoolean(SEND_IP, false)
+        manager.metricsBatchSize = config.getLong(APPLICATION_METRICS_BATCH_SIZE, APPLICATION_METRICS_BATCH_SIZE_DEFAULT)
     }
 
     companion object {
         private const val UPDATE_RATE = "application_status_update_rate"
         private const val TZ_UPDATE_RATE = "application_time_zone_update_rate"
+        private const val VERIFICATION_UPDATE_RATE = "application_time_zone_update_rate"
+        private const val APPLICATION_METRICS_BATCH_SIZE = "application_metrics_buffer_size"
+        private const val APPLICATION_METRICS_RETENTION_TIME_VALUE = "application_metrics_retention_time_value"
+        private const val APPLICATION_METRICS_RETENTION_TIME_UNIT = "application_metrics_retention_time_unit"
+        private const val APPLICATION_METRICS_BATCH_SIZE_DEFAULT = 100L
+        private const val APPLICATION_METRICS_RETENTION_TIME_VALUE_DEFAULT = 7 * 86400
+        private const val APPLICATION_METRICS_RETENTION_TIME_UNIT_DEFAULT = "day"
         private const val SEND_IP = "application_send_ip"
         internal const val UPDATE_RATE_DEFAULT = 300L // seconds == 5 minutes
+        internal const val VERIFICATION_UPDATE_RATE_DEFAULT = 300L // seconds == 5 minutes
         internal const val TZ_UPDATE_RATE_DEFAULT = 86400L // seconds == 1 day
         private const val NTP_SERVER_CONFIG = "ntp_server"
     }

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/ApplicationMetricsActivity.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/ApplicationMetricsActivity.kt
@@ -1,0 +1,116 @@
+package org.radarbase.monitor.application.ui
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.radarbase.android.storage.db.RadarApplicationDatabase
+import org.radarbase.monitor.application.R
+import org.radarbase.monitor.application.databinding.ActivityApplicationStatusBinding
+import org.radarbase.monitor.application.ui.adapter.NetworkStatusPagingAdapter
+import org.radarbase.monitor.application.ui.adapter.SourceStatusPagingAdapter
+import org.radarbase.monitor.application.ui.adapter.StringAdapter
+import org.radarbase.monitor.application.ui.viewmodel.ApplicationMetricsViewModel
+import org.radarbase.monitor.application.ui.viewmodel.factory.ApplicationMetricsViewModelFactory
+import org.radarbase.monitor.application.utils.AppRepository
+import org.radarbase.monitor.application.utils.LogNamesHolder
+
+class ApplicationMetricsActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityApplicationStatusBinding
+    private lateinit var database: RadarApplicationDatabase
+    private lateinit var repository: AppRepository
+    private val viewModel: ApplicationMetricsViewModel by viewModels { ApplicationMetricsViewModelFactory(repository) }
+
+
+    private var sourceAdapter: SourceStatusPagingAdapter? = null
+    private var networkAdapter: NetworkStatusPagingAdapter? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        binding = ActivityApplicationStatusBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.clAppPlugin)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+        database = RadarApplicationDatabase.getInstance(applicationContext)
+        repository = AppRepository(database)
+
+        setUpScrollView()
+    }
+
+    private fun setUpScrollView() {
+        binding.rvAppPlugin.layoutManager = LinearLayoutManager(this)
+
+        binding.rvAppPlugin.adapter = StringAdapter(
+            this, listOf(
+                LogNamesHolder.APPLICATION_PLUGIN_STATUS.alias,
+                LogNamesHolder.APPLICATION_NETWORK_STATUS.alias
+            )
+        ) { topicClicked ->
+            when (topicClicked) {
+                LogNamesHolder.APPLICATION_PLUGIN_STATUS.alias -> {
+                    lifecycleScope.launch {
+                        val plugins = withContext(Dispatchers.IO) {
+                            viewModel.loadDistinctPluginsFromSourceLogs()
+                        }
+                        binding.rvAppPlugin.adapter = StringAdapter(
+                            this@ApplicationMetricsActivity,
+                            plugins
+                        ) { pluginName ->
+                            if (sourceAdapter == null) {
+                                sourceAdapter = SourceStatusPagingAdapter(
+                                    this@ApplicationMetricsActivity,
+                                ) {
+                                    // Take no action when clicked on source status logs
+                                }
+                                networkAdapter = null
+                                binding.rvAppPlugin.adapter = sourceAdapter
+
+                                lifecycleScope.launch {
+                                    viewModel.getSourceStatusForPagingData(pluginName)
+                                        .collectLatest { pagingData ->
+                                            sourceAdapter?.submitData(pagingData)
+                                        }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                LogNamesHolder.APPLICATION_NETWORK_STATUS.alias -> {
+                    networkAdapter = NetworkStatusPagingAdapter(
+                        this@ApplicationMetricsActivity,
+                    ) {
+                        // No action should be taken when clicked on network status logs
+                    }
+
+                    sourceAdapter = null
+                    binding.rvAppPlugin.adapter = networkAdapter
+
+                    lifecycleScope.launch {
+                        viewModel.networkStatusPagingData.collectLatest { pagingData ->
+                            if (binding.rvAppPlugin.adapter == networkAdapter) {
+                                networkAdapter?.submitData(pagingData)
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    // Do Nothing
+                }
+            }
+        }
+    }
+}

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/ApplicationMetricsActivity.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/ApplicationMetricsActivity.kt
@@ -1,6 +1,11 @@
 package org.radarbase.monitor.application.ui
 
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
 import android.os.Bundle
+import android.os.IBinder
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -9,10 +14,17 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.radarbase.android.IRadarBinder
+import org.radarbase.android.RadarApplication.Companion.radarApp
 import org.radarbase.android.storage.db.RadarApplicationDatabase
+import org.radarbase.android.util.Boast
+import org.radarbase.monitor.application.ApplicationState
+import org.radarbase.monitor.application.ApplicationStatusProvider
 import org.radarbase.monitor.application.R
 import org.radarbase.monitor.application.databinding.ActivityApplicationStatusBinding
 import org.radarbase.monitor.application.ui.adapter.NetworkStatusPagingAdapter
@@ -22,6 +34,7 @@ import org.radarbase.monitor.application.ui.viewmodel.ApplicationMetricsViewMode
 import org.radarbase.monitor.application.ui.viewmodel.factory.ApplicationMetricsViewModelFactory
 import org.radarbase.monitor.application.utils.AppRepository
 import org.radarbase.monitor.application.utils.LogNamesHolder
+import org.slf4j.LoggerFactory
 
 class ApplicationMetricsActivity : AppCompatActivity() {
     private lateinit var binding: ActivityApplicationStatusBinding
@@ -29,9 +42,35 @@ class ApplicationMetricsActivity : AppCompatActivity() {
     private lateinit var repository: AppRepository
     private val viewModel: ApplicationMetricsViewModel by viewModels { ApplicationMetricsViewModelFactory(repository) }
 
+    private var statusProvider: ApplicationStatusProvider? = null
+    private val state: ApplicationState?
+        get() = statusProvider?.connection?.sourceState
 
     private var sourceAdapter: SourceStatusPagingAdapter? = null
     private var networkAdapter: NetworkStatusPagingAdapter? = null
+
+    private val radarServiceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            logger.debug("Service bound to ApplicationMetricsActivity")
+            val radarService = service as IRadarBinder
+
+            radarService.connections.forEach { provider ->
+                if (provider is ApplicationStatusProvider) {
+                    statusProvider = provider
+                }
+            }
+            if (state == null) {
+                logger.info("Can't send metrics state is null")
+                Boast.makeText(this@ApplicationMetricsActivity,
+                    R.string.unable_to_proceed_toast, Toast.LENGTH_SHORT).show(true)
+                return
+            }
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            statusProvider = null
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,10 +82,39 @@ class ApplicationMetricsActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+
         database = RadarApplicationDatabase.getInstance(applicationContext)
         repository = AppRepository(database)
 
+        binding.btnSend.setOnClickListener {
+            val uiManagerInterface = state?.uiManager ?: run {
+                logger.warn("Can't send the application metrics, state is null")
+                return@setOnClickListener
+            }
+
+            lifecycleScope.launch(Dispatchers.Default) {
+                val sourceStatusDeferred = async {
+                    uiManagerInterface.sendSourceStatus()
+                }
+                val networkStatusDeferred = async {
+                    uiManagerInterface.sendNetworkStatus()
+                }
+                sourceStatusDeferred.await()
+                networkStatusDeferred.await()
+                withContext(Dispatchers.Main) {
+                    finish()
+                }
+            }
+        }
+
         setUpScrollView()
+        
+        checkForStatusCounts()
+    }
+    
+    override fun onStart() {
+        super.onStart()
+        bindService(Intent(this, radarApp.radarService), radarServiceConnection, 0)
     }
 
     private fun setUpScrollView() {
@@ -112,5 +180,38 @@ class ApplicationMetricsActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    private fun checkForStatusCounts() {
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) {
+                val sourceStatusDeferred = async {
+                    viewModel.loadSourceStatusCount()
+                }
+
+                val networkStatusDeferred = async {
+                    viewModel.loadNetworkStatusCount()
+                }
+
+                val sourceStatusCounts = sourceStatusDeferred.await()
+                val networkStatusCounts = networkStatusDeferred.await()
+
+                withContext(Dispatchers.Main) {
+                    binding.tvPluginStatus.text = getString(R.string.plugin_log_count, sourceStatusCounts)
+                    binding.tvNetworkStatus.text = getString(R.string.network_log_count, networkStatusCounts)
+                }
+            }
+
+            delay((state?.uiStatusUpdateRate ?: 60) * 1000)
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        unbindService(radarServiceConnection)
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(ApplicationMetricsActivity::class.java)
     }
 }

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/NetworkStatusPagingAdapter.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/NetworkStatusPagingAdapter.kt
@@ -23,7 +23,7 @@ class NetworkStatusPagingAdapter(
         fun bind(log: NetworkStatusLog) {
             binding.tvStatusInfo.text = context.getString(
                 R.string.network_status_info,
-                log.connectionState.name,
+                log.connectionStatus.name,
                 dateTimeFromInstant(log.time)
             )
 

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/NetworkStatusPagingAdapter.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/NetworkStatusPagingAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import org.radarbase.android.storage.entity.NetworkStatusLog
 import org.radarbase.monitor.application.R
-import org.radarbase.monitor.application.databinding.ItemLogRowBinding
+import org.radarbase.monitor.application.databinding.ClickableStringRowBinding
 import org.radarbase.monitor.application.utils.dateTimeFromInstant
 
 class NetworkStatusPagingAdapter(
@@ -18,10 +18,10 @@ class NetworkStatusPagingAdapter(
     DIFF_CALLBACK
 ) {
 
-    inner class NetworkStatusViewHolder(private val binding: ItemLogRowBinding) :
+    inner class NetworkStatusViewHolder(private val binding: ClickableStringRowBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(log: NetworkStatusLog) {
-            binding.tvStatusInfo.text = context.getString(
+            binding.tvStringInfo.text = context.getString(
                 R.string.network_status_info,
                 log.connectionStatus.name,
                 dateTimeFromInstant(log.time)
@@ -39,7 +39,7 @@ class NetworkStatusPagingAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NetworkStatusViewHolder {
-        val binding = ItemLogRowBinding.inflate(LayoutInflater.from(context), parent, false)
+        val binding = ClickableStringRowBinding.inflate(LayoutInflater.from(context), parent, false)
         return NetworkStatusViewHolder(binding)
     }
 

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/NetworkStatusPagingAdapter.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/NetworkStatusPagingAdapter.kt
@@ -1,0 +1,63 @@
+package org.radarbase.monitor.application.ui.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import org.radarbase.android.storage.entity.NetworkStatusLog
+import org.radarbase.monitor.application.R
+import org.radarbase.monitor.application.databinding.ItemLogRowBinding
+import org.radarbase.monitor.application.utils.dateTimeFromInstant
+
+class NetworkStatusPagingAdapter(
+    private val context: Context,
+    private val onClickAction: (NetworkStatusLog) -> Unit
+) : PagingDataAdapter<NetworkStatusLog, NetworkStatusPagingAdapter.NetworkStatusViewHolder>(
+    DIFF_CALLBACK
+) {
+
+    inner class NetworkStatusViewHolder(private val binding: ItemLogRowBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(log: NetworkStatusLog) {
+            binding.tvStatusInfo.text = context.getString(
+                R.string.network_status_info,
+                log.connectionState.name,
+                dateTimeFromInstant(log.time)
+            )
+
+            binding.root.setOnClickListener {
+                log.apply(onClickAction)
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: NetworkStatusViewHolder, position: Int) {
+        val log = getItem(position) ?: return
+        holder.bind(log)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NetworkStatusViewHolder {
+        val binding = ItemLogRowBinding.inflate(LayoutInflater.from(context), parent, false)
+        return NetworkStatusViewHolder(binding)
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<NetworkStatusLog>() {
+            override fun areItemsTheSame(
+                oldItem: NetworkStatusLog,
+                newItem: NetworkStatusLog
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: NetworkStatusLog,
+                newItem: NetworkStatusLog
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/SourceStatusPagingAdapter.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/SourceStatusPagingAdapter.kt
@@ -1,0 +1,63 @@
+package org.radarbase.monitor.application.ui.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import org.radarbase.android.storage.entity.SourceStatusLog
+import org.radarbase.monitor.application.R
+import org.radarbase.monitor.application.databinding.ItemLogRowBinding
+import org.radarbase.monitor.application.utils.dateTimeFromInstant
+
+class SourceStatusPagingAdapter(
+    private val context: Context,
+    private val onClickAction: (SourceStatusLog) -> Unit
+) : PagingDataAdapter<SourceStatusLog, SourceStatusPagingAdapter.SourceStatusViewHolder>(
+    DIFF_CALLBACK
+) {
+
+    inner class SourceStatusViewHolder(private val binding: ItemLogRowBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(log: SourceStatusLog) {
+            binding.tvStatusInfo.text = context.getString(
+                R.string.source_status_info,
+                log.sourceStatus.name,
+                dateTimeFromInstant(log.time)
+            )
+
+            binding.root.setOnClickListener {
+                log.apply(onClickAction)
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: SourceStatusViewHolder, position: Int) {
+        val log = getItem(position) ?: return
+        holder.bind(log)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SourceStatusViewHolder {
+        val binding = ItemLogRowBinding.inflate(LayoutInflater.from(context), parent, false)
+        return SourceStatusViewHolder(binding)
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<SourceStatusLog>() {
+            override fun areItemsTheSame(
+                oldItem: SourceStatusLog,
+                newItem: SourceStatusLog
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: SourceStatusLog,
+                newItem: SourceStatusLog
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/SourceStatusPagingAdapter.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/SourceStatusPagingAdapter.kt
@@ -8,7 +8,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import org.radarbase.android.storage.entity.SourceStatusLog
 import org.radarbase.monitor.application.R
-import org.radarbase.monitor.application.databinding.ItemLogRowBinding
+import org.radarbase.monitor.application.databinding.ClickableStringRowBinding
 import org.radarbase.monitor.application.utils.dateTimeFromInstant
 
 class SourceStatusPagingAdapter(
@@ -18,10 +18,10 @@ class SourceStatusPagingAdapter(
     DIFF_CALLBACK
 ) {
 
-    inner class SourceStatusViewHolder(private val binding: ItemLogRowBinding) :
+    inner class SourceStatusViewHolder(private val binding: ClickableStringRowBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(log: SourceStatusLog) {
-            binding.tvStatusInfo.text = context.getString(
+            binding.tvStringInfo.text = context.getString(
                 R.string.source_status_info,
                 log.sourceStatus.name,
                 dateTimeFromInstant(log.time)
@@ -39,7 +39,7 @@ class SourceStatusPagingAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SourceStatusViewHolder {
-        val binding = ItemLogRowBinding.inflate(LayoutInflater.from(context), parent, false)
+        val binding = ClickableStringRowBinding.inflate(LayoutInflater.from(context), parent, false)
         return SourceStatusViewHolder(binding)
     }
 

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/StringAdapter.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/StringAdapter.kt
@@ -1,0 +1,41 @@
+package org.radarbase.monitor.application.ui.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import org.radarbase.monitor.application.databinding.ClickableStringRowBinding
+
+class StringAdapter(
+    private val context: Context,
+    private val contents: List<String>,
+    private val itemClickAction: (String) -> Unit
+) : RecyclerView.Adapter<StringAdapter.StringViewHolder>() {
+
+    inner class StringViewHolder(val binding: ClickableStringRowBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bindView(item: String) {
+            binding.tvStringInfo.text = item
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StringViewHolder {
+        val viewBinding = ClickableStringRowBinding.inflate(
+            LayoutInflater.from(context),
+            parent,
+            false
+        )
+
+        return StringViewHolder(viewBinding)
+    }
+
+    override fun onBindViewHolder(holder: StringViewHolder, position: Int) {
+        val content = contents[position]
+        holder.bindView(content)
+        holder.binding.clStringItem.setOnClickListener {
+            content.apply(itemClickAction)
+        }
+    }
+
+    override fun getItemCount(): Int = contents.size
+}

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/StringAdapter.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/adapter/StringAdapter.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import org.radarbase.monitor.application.databinding.ClickableStringRowBinding
+import org.radarbase.monitor.application.databinding.ItemLogRowBinding
 
 class StringAdapter(
     private val context: Context,
@@ -12,15 +12,15 @@ class StringAdapter(
     private val itemClickAction: (String) -> Unit
 ) : RecyclerView.Adapter<StringAdapter.StringViewHolder>() {
 
-    inner class StringViewHolder(val binding: ClickableStringRowBinding) :
+    inner class StringViewHolder(val binding: ItemLogRowBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bindView(item: String) {
-            binding.tvStringInfo.text = item
+            binding.tvStatusInfo.text = item
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StringViewHolder {
-        val viewBinding = ClickableStringRowBinding.inflate(
+        val viewBinding = ItemLogRowBinding.inflate(
             LayoutInflater.from(context),
             parent,
             false
@@ -32,7 +32,7 @@ class StringAdapter(
     override fun onBindViewHolder(holder: StringViewHolder, position: Int) {
         val content = contents[position]
         holder.bindView(content)
-        holder.binding.clStringItem.setOnClickListener {
+        holder.binding.btnMoreInfo.setOnClickListener {
             content.apply(itemClickAction)
         }
     }

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/viewmodel/ApplicationMetricsViewModel.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/viewmodel/ApplicationMetricsViewModel.kt
@@ -1,0 +1,53 @@
+package org.radarbase.monitor.application.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import kotlinx.coroutines.flow.Flow
+import org.radarbase.android.storage.dao.NetworkStatusDao
+import org.radarbase.android.storage.dao.SourceStatusDao
+import org.radarbase.android.storage.entity.NetworkStatusLog
+import org.radarbase.android.storage.entity.SourceStatusLog
+
+class ApplicationMetricsViewModel(
+    private val sourceStatusDao: SourceStatusDao,
+    private val networkStatusDao: NetworkStatusDao
+) : ViewModel() {
+
+    val networkStatusPagingData: Flow<PagingData<NetworkStatusLog>> = Pager(
+        config = PagingConfig(
+            pageSize = 20,
+            enablePlaceholders = false
+        ),
+        pagingSourceFactory = {
+            networkStatusDao.pagingSource()
+        }
+    ).flow.cachedIn(viewModelScope)
+
+    suspend fun getSourceStatusForPagingData(pluginName: String): Flow<PagingData<SourceStatusLog>> {
+        return Pager (
+            config = PagingConfig(
+                pageSize = 20,
+                enablePlaceholders = false
+            ),
+            pagingSourceFactory = {
+                sourceStatusDao.pagingSourceByPluginName(pluginName)
+            }
+        ).flow.cachedIn(viewModelScope)
+    }
+
+    suspend fun loadDistinctPluginsFromSourceLogs(): List<String> {
+        return sourceStatusDao.loadDistinctPlugins()
+    }
+
+    suspend fun loadStatusByPluginNameFromSourceLogs(pluginName: String): List<SourceStatusLog> {
+        return sourceStatusDao.loadStatusesByPluginName(pluginName)
+    }
+
+    suspend fun loadAllNetworkLogs(): List<NetworkStatusLog> {
+        return networkStatusDao.loadAllNetworkLogs()
+    }
+}

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/viewmodel/ApplicationMetricsViewModel.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/viewmodel/ApplicationMetricsViewModel.kt
@@ -12,6 +12,7 @@ import org.radarbase.android.storage.dao.SourceStatusDao
 import org.radarbase.android.storage.entity.NetworkStatusLog
 import org.radarbase.android.storage.entity.SourceStatusLog
 
+@Suppress("unused")
 class ApplicationMetricsViewModel(
     private val sourceStatusDao: SourceStatusDao,
     private val networkStatusDao: NetworkStatusDao
@@ -27,7 +28,7 @@ class ApplicationMetricsViewModel(
         }
     ).flow.cachedIn(viewModelScope)
 
-    suspend fun getSourceStatusForPagingData(pluginName: String): Flow<PagingData<SourceStatusLog>> {
+    fun getSourceStatusForPagingData(pluginName: String): Flow<PagingData<SourceStatusLog>> {
         return Pager (
             config = PagingConfig(
                 pageSize = 20,
@@ -49,5 +50,13 @@ class ApplicationMetricsViewModel(
 
     suspend fun loadAllNetworkLogs(): List<NetworkStatusLog> {
         return networkStatusDao.loadAllNetworkLogs()
+    }
+
+    suspend fun loadSourceStatusCount(): Int {
+        return sourceStatusDao.getStatusesCount()
+    }
+
+    suspend fun loadNetworkStatusCount(): Int {
+        return networkStatusDao.getStatusesCount()
     }
 }

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/viewmodel/factory/ApplicationMetricsViewModelFactory.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/ui/viewmodel/factory/ApplicationMetricsViewModelFactory.kt
@@ -1,0 +1,19 @@
+package org.radarbase.monitor.application.ui.viewmodel.factory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import org.radarbase.monitor.application.ui.viewmodel.ApplicationMetricsViewModel
+import org.radarbase.monitor.application.utils.AppRepository
+
+class ApplicationMetricsViewModelFactory(private val repository: AppRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ApplicationMetricsViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return ApplicationMetricsViewModel(
+                repository.sourceStatusDao,
+                repository.networkStatusDao
+            ) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/utils/AppRepository.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/utils/AppRepository.kt
@@ -4,7 +4,7 @@ import org.radarbase.android.storage.dao.NetworkStatusDao
 import org.radarbase.android.storage.dao.SourceStatusDao
 import org.radarbase.android.storage.db.RadarApplicationDatabase
 
-class AppRepository(private val db: RadarApplicationDatabase) {
+class AppRepository(db: RadarApplicationDatabase) {
     val sourceStatusDao: SourceStatusDao = db.sourceStatusDao()
     val networkStatusDao: NetworkStatusDao = db.networkStatusDao()
 }

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/utils/AppRepository.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/utils/AppRepository.kt
@@ -1,0 +1,10 @@
+package org.radarbase.monitor.application.utils
+
+import org.radarbase.android.storage.dao.NetworkStatusDao
+import org.radarbase.android.storage.dao.SourceStatusDao
+import org.radarbase.android.storage.db.RadarApplicationDatabase
+
+class AppRepository(private val db: RadarApplicationDatabase) {
+    val sourceStatusDao: SourceStatusDao = db.sourceStatusDao()
+    val networkStatusDao: NetworkStatusDao = db.networkStatusDao()
+}

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/utils/LogNamesHolder.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/utils/LogNamesHolder.kt
@@ -1,0 +1,6 @@
+package org.radarbase.monitor.application.utils
+
+enum class LogNamesHolder(val alias: String) {
+    APPLICATION_PLUGIN_STATUS("Application Plugin Status"),
+    APPLICATION_NETWORK_STATUS("Application Network Status")
+}

--- a/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/utils/Utils.kt
+++ b/plugins/radar-android-application-status/src/main/java/org/radarbase/monitor/application/utils/Utils.kt
@@ -1,0 +1,12 @@
+package org.radarbase.monitor.application.utils
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+fun dateTimeFromInstant(epochSeconds: Long): String {
+    return DateTimeFormatter
+        .ofPattern("yyyy-MM-dd HH:mm:ss")
+        .withZone(ZoneId.systemDefault())
+        .format(Instant.ofEpochSecond(epochSeconds))
+}

--- a/plugins/radar-android-application-status/src/main/res/layout/activity_application_status.xml
+++ b/plugins/radar-android-application-status/src/main/res/layout/activity_application_status.xml
@@ -11,9 +11,57 @@
         android:id="@+id/rvAppPlugin"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginTop="15dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="80dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btnSend"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/send"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="10dp"
+        android:paddingStart="3dp"
+        android:paddingEnd="3dp"
+        android:textStyle="bold"
+        android:background="?attr/colorPrimary"
+        app:layout_constraintTop_toBottomOf="@+id/rvAppPlugin"
+        tools:layout_editor_absoluteX="148dp"
+        tools:layout_editor_absoluteY="652dp" />
+
+    <TextView
+        android:id="@+id/tvNetworkStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/rvAppPlugin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/btnSend"
+        android:text="@string/network_logs"
+        android:textStyle="bold"
+        android:background="?attr/colorPrimary"
+        tools:layout_editor_absoluteX="25dp"
+        tools:layout_editor_absoluteY="696dp" />
+
+    <TextView
+        android:id="@+id/tvPluginStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/plugin_logs"
+        tools:layout_editor_absoluteX="306dp"
+        app:layout_constraintStart_toEndOf="@+id/btnSend"
+        app:layout_constraintTop_toBottomOf="@+id/rvAppPlugin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:background="?attr/colorPrimary"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:layout_editor_absoluteY="690dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugins/radar-android-application-status/src/main/res/layout/activity_application_status.xml
+++ b/plugins/radar-android-application-status/src/main/res/layout/activity_application_status.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/clAppPlugin"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.ApplicationMetricsActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvAppPlugin"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/plugins/radar-android-application-status/src/main/res/layout/clickable_string_row.xml
+++ b/plugins/radar-android-application-status/src/main/res/layout/clickable_string_row.xml
@@ -27,7 +27,7 @@
             android:layout_marginStart="5dp"
             android:text="@string/dummy_topic_name"
             android:textStyle="bold"
-            android:textSize="16sp"
+            android:textSize="15sp"
             android:padding="4dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/plugins/radar-android-application-status/src/main/res/layout/clickable_string_row.xml
+++ b/plugins/radar-android-application-status/src/main/res/layout/clickable_string_row.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="5dp"
+    android:layout_marginBottom="5dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
+    app:cardCornerRadius="15dp"
+    android:elevation="8dp"
+    app:cardBackgroundColor="?attr/colorPrimary"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_string_item"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_string_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:text="@string/dummy_topic_name"
+            android:textStyle="bold"
+            android:textSize="16sp"
+            android:padding="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.5" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/plugins/radar-android-application-status/src/main/res/layout/item_log_row.xml
+++ b/plugins/radar-android-application-status/src/main/res/layout/item_log_row.xml
@@ -35,6 +35,7 @@
             app:layout_constraintVertical_bias="0.5" />
 
         <Button
+            android:id="@+id/btn_more_info"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/text_more_info"

--- a/plugins/radar-android-application-status/src/main/res/layout/item_log_row.xml
+++ b/plugins/radar-android-application-status/src/main/res/layout/item_log_row.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="5dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="5dp"
+    android:elevation="8dp"
+    app:cardBackgroundColor="?attr/colorPrimary"
+    app:cardCornerRadius="15dp"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/clItemLog"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/tv_status_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:text="@string/dummy_plugin_status"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.5" />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/text_more_info"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/plugins/radar-android-application-status/src/main/res/values/colors.xml
+++ b/plugins/radar-android-application-status/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="black">#0C0C0C</color>
+</resources>

--- a/plugins/radar-android-application-status/src/main/res/values/strings.xml
+++ b/plugins/radar-android-application-status/src/main/res/values/strings.xml
@@ -1,4 +1,12 @@
 <resources>
     <string name="applicationServiceDisplayName">Application</string>
     <string name="application_status_description">Monitors how much data the app is collecting and server status.</string>
+    <string name="dummy_topic_name">Application Plugin Status</string>
+    <string name="btn_info_text">More Info</string>
+    <string name="source_status_info">%1$s (%2$s)</string>
+    <string name="network_status_info">%1$s (%2$s)</string>
+    <string name="empty_text" />
+    <string name="text_more_info">More Info</string>
+    <string name="dummy_plugin_status">Android Phone Battery Usage</string>
+    <string name="start_app_metrics_activity">Radar Application Status</string>
 </resources>

--- a/plugins/radar-android-application-status/src/main/res/values/strings.xml
+++ b/plugins/radar-android-application-status/src/main/res/values/strings.xml
@@ -9,4 +9,10 @@
     <string name="text_more_info">More Info</string>
     <string name="dummy_plugin_status">Android Phone Battery Usage</string>
     <string name="start_app_metrics_activity">Radar Application Status</string>
+    <string name="send">Send</string>
+    <string name="unable_to_proceed_toast">Cannot process request, the plugin status is not CONNECTED. Please try reconnecting the plugin.</string>
+    <string name="network_logs">Network Logs\n1234</string>
+    <string name="plugin_logs">Plugin Logs\n1234</string>
+    <string name="plugin_log_count">Plugin Logs \n%1$d</string>
+    <string name="network_log_count">Network Logs \n%1$d</string>
 </resources>

--- a/radar-commons-android/build.gradle
+++ b/radar-commons-android/build.gradle
@@ -16,6 +16,7 @@
 
 apply from: "$rootDir/gradle/android.gradle"
 apply plugin: 'kotlinx-serialization'
+apply plugin: 'androidx.room'
 
 android {
     namespace "org.radarbase.android"
@@ -25,6 +26,9 @@ android {
     buildFeatures {
         viewBinding true
         buildConfig true
+    }
+    room {
+        schemaDirectory "$projectDir/src/main/res/schemas"
     }
 }
 
@@ -63,10 +67,21 @@ dependencies {
     implementation "com.google.firebase:firebase-crashlytics"
     implementation "com.gitlab.mvysny.slf4j:slf4j-handroid:$slf4j_handroid_version"
 
+    implementation "androidx.room:room-runtime:$room_version"
+    kapt "androidx.room:room-compiler:$room_version" // Required for annotation processing
+    implementation "androidx.room:room-ktx:$room_version" // For Kotlin Coroutines support
+
+    implementation "androidx.paging:paging-runtime:$paging_version"
+    implementation "androidx.room:room-paging:$room_version"
+
     implementation("io.ktor:ktor-client-content-negotiation")
     implementation("io.ktor:ktor-serialization-kotlinx-json")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
     androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
+}
+
+afterEvaluate {
+    tasks["dokkaJavadoc"].dependsOn(tasks.getByName("kaptReleaseKotlin"), tasks.getByName("kaptDebugKotlin"))
 }
 
 apply from: "$rootDir/gradle/test.gradle"

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -147,8 +147,12 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
     private val _serverStatus: MutableStateFlow<ServerStatus> =
         MutableStateFlow(ServerStatus.DISCONNECTED)
 
+    private val _sourceStatus: MutableStateFlow<SourceStatusTrace> =
+        MutableStateFlow(SourceStatusTrace(status = SourceStatusListener.Status.DISCONNECTED))
+
     override val recordsSent: SharedFlow<TopicSendReceipt> = _recordsSent.asSharedFlow()
     override val serverStatus: StateFlow<ServerStatus> = _serverStatus
+    val sourceStatus: StateFlow<SourceStatusTrace> = _sourceStatus
 
     private var _actionBluetoothNeeded: MutableStateFlow<NeedsBluetoothState> = MutableStateFlow(BluetoothNeeded)
     val actionBluetoothNeeded: StateFlow<NeedsBluetoothState> = _actionBluetoothNeeded
@@ -502,6 +506,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
     }
 
     fun sourceStatusUpdated(connection: SourceServiceConnection<*>, status: SourceStatusListener.Status) {
+        _sourceStatus.value = SourceStatusTrace(connection.sourceName, status)
         logger.info("Source of {} was updated to {}", connection, status)
         if (status == SourceStatusListener.Status.CONNECTED) {
             logger.info("Device name is {} while connecting.", connection.sourceName)

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/SourceServiceConnection.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/SourceServiceConnection.kt
@@ -43,7 +43,7 @@ class SourceServiceConnection<S : BaseSourceState>(
 
         radarService.run {
             serviceJob = lifecycleScope.launch {
-                sourceStatus
+                super.sourceStatus
                     ?.collect {
                         logger.info("Source status changed of source: $sourceName with service class: {}", serviceClassName)
                         radarService.sourceStatusUpdated(this@SourceServiceConnection, it)

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/SourceStatusListener.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/SourceStatusListener.kt
@@ -49,3 +49,8 @@ interface SourceStatusListener {
      */
     fun sourceFailedToConnect(name: String)
 }
+
+data class SourceStatusTrace(
+    val plugin: String? = null,
+    val status: SourceStatusListener.Status
+)

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/converter/Converters.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/converter/Converters.kt
@@ -2,7 +2,7 @@ package org.radarbase.android.storage.converter
 
 import androidx.room.TypeConverter
 import org.radarbase.android.source.SourceStatusListener
-import org.radarbase.android.storage.entity.NetworkStatus
+import org.radarbase.android.storage.entity.ConnectionStatus
 
 @Suppress("unused")
 class Converters {
@@ -14,9 +14,9 @@ class Converters {
         SourceStatusListener.Status.valueOf(statusName)
 
     @TypeConverter
-    fun fromNetworkStatus(status: NetworkStatus): String = status.name
+    fun fromNetworkStatus(status: ConnectionStatus): String = status.name
 
     @TypeConverter
-    fun toNetworkStatus(statusName: String): NetworkStatus =
-        NetworkStatus.valueOf(statusName)
+    fun toNetworkStatus(statusName: String): ConnectionStatus =
+        ConnectionStatus.valueOf(statusName)
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/converter/Converters.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/converter/Converters.kt
@@ -1,0 +1,22 @@
+package org.radarbase.android.storage.converter
+
+import androidx.room.TypeConverter
+import org.radarbase.android.source.SourceStatusListener
+import org.radarbase.android.storage.entity.NetworkStatus
+
+@Suppress("unused")
+class Converters {
+    @TypeConverter
+    fun fromSourceStatus(status: SourceStatusListener.Status): String = status.name
+
+    @TypeConverter
+    fun toSourceStatus(statusName: String): SourceStatusListener.Status =
+        SourceStatusListener.Status.valueOf(statusName)
+
+    @TypeConverter
+    fun fromNetworkStatus(status: NetworkStatus): String = status.name
+
+    @TypeConverter
+    fun toNetworkStatus(statusName: String): NetworkStatus =
+        NetworkStatus.valueOf(statusName)
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/BaseDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/BaseDao.kt
@@ -35,7 +35,7 @@ interface BaseDao<T> {
      * @param rows a variable number of entities to be inserted.
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun addAll(vararg rows: T)
+    fun addAll(rows: List<T>)
 
     /**
      * Updates the given [data] in the database.

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/BaseDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/BaseDao.kt
@@ -1,0 +1,63 @@
+package org.radarbase.android.storage.dao
+
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Update
+
+/**
+ * A generic base Data Access Object (DAO) interface providing standard CRUD operations.
+ *
+ * This interface defines common methods for adding, updating, and deleting entities of type [T].
+ * Implementing DAOs can extend this interface to inherit these operations.
+ *
+ * @param T the type of entity for which the operations are provided.
+ */
+@Suppress("unused")
+interface BaseDao<T> {
+
+    /**
+     * Inserts the given [data] into the database.
+     *
+     * If a conflict occurs (e.g. a record with the same primary key already exists),
+     * the existing record will be replaced.
+     *
+     * @param data the entity to be inserted.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun add(data: T)
+
+    /**
+     * Inserts the given [rows] into the database.
+     *
+     * If a conflict occurs, the existing records will be replaced.
+     *
+     * @param rows a variable number of entities to be inserted.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun addAll(vararg rows: T)
+
+    /**
+     * Updates the given [data] in the database.
+     *
+     * @param data the entity with updated values.
+     */
+    @Update
+    fun update(data: T)
+
+    /**
+     * Deletes the specified [row] from the database.
+     *
+     * @param row the entity to be deleted.
+     */
+    @Delete
+    fun delete(row: T)
+
+    /**
+     * Deletes the specified [rows] from the database.
+     *
+     * @param rows a variable number of entities to be deleted.
+     */
+    @Delete
+    fun deleteAll(vararg rows: T)
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/NetworkStatusDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/NetworkStatusDao.kt
@@ -62,6 +62,14 @@ abstract class NetworkStatusDao : BaseDao<NetworkStatusLog> {
     abstract fun pagingSource(): PagingSource<Long, NetworkStatusLog>
 
     /**
+     * Retrieves the total number of status logs present in the [source_status_log] table.
+     *
+     * @return the count of status logs.
+     */
+    @Query("SELECT COUNT(*) FROM source_status_log")
+    abstract suspend fun getStatusesCount(): Int
+
+    /**
      * Deletes network status log records with a [NetworkStatusLog.time] value between the specified [from] and [to] timestamps.
      *
      * @param from the start timestamp (inclusive) for deletion.

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/NetworkStatusDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/NetworkStatusDao.kt
@@ -62,7 +62,7 @@ abstract class NetworkStatusDao : BaseDao<NetworkStatusLog> {
     abstract fun pagingSource(): PagingSource<Long, NetworkStatusLog>
 
     /**
-     * Retrieves the total number of status logs present in the [source_status_log] table.
+     * Retrieves the total number of status logs present in the table.
      *
      * @return the count of status logs.
      */
@@ -95,6 +95,8 @@ abstract class NetworkStatusDao : BaseDao<NetworkStatusLog> {
      * For example, if the table has 100 records and [count] is set to 80, then the 20 oldest records will be deleted.
      *
      * @param count the maximum number of recent records to retain.
+     * @return the number of rows that were deleted.
+     *
      */
     @Query(
         """
@@ -106,5 +108,20 @@ abstract class NetworkStatusDao : BaseDao<NetworkStatusLog> {
         )
         """
     )
-    abstract suspend fun deleteNetworkLogsCountGreaterThan(count: Long)
+    abstract suspend fun deleteNetworkLogsCountGreaterThan(count: Long): Int
+
+    /**
+     * Deletes network status log records that are older than the specified [time] threshold.
+     *
+     * Useful for removing logs that are older than a certain retention period.
+     *
+     * @param time the timestamp threshold. All network status logs with a `time` less than this value will be deleted.
+     * @return the number of rows that were deleted.
+     */
+    @Query(
+        """
+    DELETE FROM network_status_log WHERE time < :time
+    """
+    )
+    abstract suspend fun deleteNetworkLogsOlderThan(time: Long): Int
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/NetworkStatusDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/NetworkStatusDao.kt
@@ -1,0 +1,102 @@
+package org.radarbase.android.storage.dao
+
+import androidx.paging.PagingSource
+import androidx.room.Dao
+import androidx.room.Query
+import org.radarbase.android.storage.entity.NetworkStatusLog
+import org.radarbase.android.storage.entity.SourceStatusLog
+
+/**
+ * Data Access Object (DAO) for performing operations on the [NetworkStatusLog] table.
+ *
+ * This DAO extends [BaseDao] to provide standard CRUD operations and adds methods
+ * specific to managing network status logs, such as retrieving logs within a time range,
+ * fetching logs older than a given timestamp, and deleting logs based on time or count constraints.
+ */
+@Suppress("unused")
+@Dao
+abstract class NetworkStatusDao : BaseDao<NetworkStatusLog> {
+
+    /**
+     * Retrieves all network status log records from the database.
+     *
+     * @return a list of all [NetworkStatusLog] entries.
+     */
+    @Query("SELECT * FROM network_status_log")
+    abstract suspend fun loadAllNetworkLogs(): List<NetworkStatusLog>
+
+    /**
+     * Retrieves network status log records with a [NetworkStatusLog.time] value between the specified [from] and [to] timestamps.
+     *
+     * @param from the start timestamp (inclusive).
+     * @param to the end timestamp (inclusive).
+     * @return a list of [NetworkStatusLog] entries within the specified time range.
+     */
+    @Query("SELECT * FROM network_status_log WHERE time BETWEEN :from AND :to")
+    abstract suspend fun loadNetworkLogsBetweenTimestamps(
+        from: Long,
+        to: Long
+    ): List<NetworkStatusLog>
+
+    /**
+     * Retrieves network status log records with a [NetworkStatusLog.time] value less than the specified [time].
+     *
+     * This method is useful for fetching logs that are older than the given timestamp,
+     * for example, when you want to delete logs older than 7 days.
+     *
+     * @param time the timestamp threshold, logs with a time less than this value are considered old.
+     * @return a list of [NetworkStatusLog] entries with a [time] value less than the specified threshold.
+     */
+    @Query("SELECT * FROM network_status_log WHERE time < :time")
+    abstract suspend fun loadNetworkLogsOlderThan(time: Long): List<NetworkStatusLog>
+
+    /**
+     * Returns a [PagingSource] for loading [NetworkStatusLog] records in pages.
+     *
+     * The [PagingSource] loads data in chunks (pages) as needed when the user scrolls,
+     * rather than loading all records at once. The records are sorted by [NetworkStatusLog.time] in descending order.
+     *
+     * @return a [PagingSource] that loads pages of [SourceStatusLog] items.
+     */
+    @Query("SELECT * FROM network_status_log ORDER BY time ASC")
+    abstract fun pagingSource(): PagingSource<Long, NetworkStatusLog>
+
+    /**
+     * Deletes network status log records with a [NetworkStatusLog.time] value between the specified [from] and [to] timestamps.
+     *
+     * @param from the start timestamp (inclusive) for deletion.
+     * @param to the end timestamp (inclusive) for deletion.
+     */
+    @Query("DELETE FROM network_status_log WHERE time BETWEEN :from AND :to")
+    abstract suspend fun deleteNetworkLogsBetweenTimestamps(from: Long, to: Long)
+
+    /**
+     * Deletes the network status log record with the specified [id].
+     *
+     * @param id the unique identifier of the network log to delete.
+     */
+    @Query("DELETE FROM network_status_log WHERE id = :id")
+    abstract suspend fun deleteNetworkLogById(id: Long)
+
+    /**
+     * Deletes the oldest network status log records so that the total number of records does not exceed [count].
+     *
+     * Calculates how many records are in excess by subtracting [count] from the total number
+     * of records in the table. It then deletes that many oldest records.
+     *
+     * For example, if the table has 100 records and [count] is set to 80, then the 20 oldest records will be deleted.
+     *
+     * @param count the maximum number of recent records to retain.
+     */
+    @Query(
+        """
+        DELETE FROM network_status_log 
+        WHERE id IN (
+            SELECT id FROM network_status_log 
+            ORDER BY time ASC 
+            LIMIT (SELECT COUNT(*) - :count FROM network_status_log)
+        )
+        """
+    )
+    abstract suspend fun deleteNetworkLogsCountGreaterThan(count: Long)
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/NetworkStatusDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/NetworkStatusDao.kt
@@ -59,7 +59,7 @@ abstract class NetworkStatusDao : BaseDao<NetworkStatusLog> {
      * @return a [PagingSource] that loads pages of [SourceStatusLog] items.
      */
     @Query("SELECT * FROM network_status_log ORDER BY time ASC")
-    abstract fun pagingSource(): PagingSource<Long, NetworkStatusLog>
+    abstract fun pagingSource(): PagingSource<Int, NetworkStatusLog>
 
     /**
      * Retrieves the total number of status logs present in the table.

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/SourceStatusDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/SourceStatusDao.kt
@@ -78,6 +78,14 @@ abstract class SourceStatusDao : BaseDao<SourceStatusLog> {
     abstract fun pagingSourceByPluginName(pluginName: String): PagingSource<Long, SourceStatusLog>
 
     /**
+     * Retrieves the total number of status logs present in the [source_status_log] table.
+     *
+     * @return the count of status logs.
+     */
+    @Query("SELECT COUNT(*) FROM source_status_log")
+    abstract suspend fun getStatusesCount(): Int
+
+    /**
      * Deletes source status log records that have a [SourceStatusLog.time] value between the specified [from] and [to] timestamps.
      *
      * @param from the start timestamp (inclusive) for deletion.

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/SourceStatusDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/SourceStatusDao.kt
@@ -1,0 +1,119 @@
+package org.radarbase.android.storage.dao
+
+import androidx.paging.PagingSource
+import androidx.room.Dao
+import androidx.room.Query
+import org.radarbase.android.storage.entity.SourceStatusLog
+
+/**
+ * Data Access Object (DAO) for performing operations on the [SourceStatusLog] table.
+ *
+ * This DAO extends [BaseDao] to provide basic CRUD operations and adds additional queries
+ * specific to [SourceStatusLog] such as fetching records within a time range and deleting
+ * records based on specific criteria.
+ */
+@Suppress("unused")
+@Dao
+abstract class SourceStatusDao : BaseDao<SourceStatusLog> {
+
+    /**
+     * Retrieves all the source status log records from the database.
+     *
+     * @return a list of all [SourceStatusLog] entries.
+     */
+    @Query("SELECT * FROM source_status_log")
+    abstract suspend fun loadAllStatuses(): List<SourceStatusLog>
+
+    /**
+     * Retrieves source status log records that have a [SourceStatusLog.time] value between the given [from] and [to] timestamps.
+     *
+     * @param from the start timestamp (inclusive).
+     * @param to the end timestamp (inclusive).
+     * @return a list of [SourceStatusLog] entries that fall within the specified time range.
+     */
+    @Query("SELECT * FROM source_status_log WHERE time BETWEEN :from AND :to")
+    abstract suspend fun loadStatusesBetweenTimestamps(from: Long, to: Long): List<SourceStatusLog>
+
+    /**
+     * Retrieves records with a [SourceStatusLog.time] value less than the specified [time].
+     *
+     * This can be used to fetch records that are older than the given timestamp,
+     * for instance, to delete logs older than 7 days.
+     *
+     * @param time the timestamp threshold, logs with a time less than this value are considered old.
+     * @return a list of [SourceStatusLog] entries with a [time] value less than the specified threshold.
+     */
+    @Query("SELECT * FROM source_status_log WHERE time < :time")
+    abstract suspend fun loadStatusesOlderThan(time: Long): List<SourceStatusLog>
+
+    /**
+     * Retrieves a list of distinct plugin.
+     *
+     * @return a list of unique plugin names.
+     */
+    @Query("SELECT DISTINCT plugin FROM source_status_log")
+    abstract suspend fun loadDistinctPlugins(): List<String>
+
+    /**
+     * Retrieves all [SourceStatusLog] records that match the specified plugin name.
+     *
+     * This query filters the records in the source_status_log table based on the value of the
+     * [SourceStatusLog.plugin].
+     *
+     * @param pluginName the name of the plugin to filter by.
+     * @return a list of [SourceStatusLog] entries corresponding to the specified plugin.
+     */
+    @Query("SELECT * FROM source_status_log WHERE plugin = :pluginName")
+    abstract suspend fun loadStatusesByPluginName(pluginName: String): List<SourceStatusLog>
+
+    /**
+     * Returns a [PagingSource] for loading [SourceStatusLog] records in pages.
+     *
+     * The [PagingSource] loads data in chunks (pages) as needed when the user scrolls,
+     * rather than loading all records at once. The records are sorted by [SourceStatusLog.time] in descending order.
+     *
+     * @return a [PagingSource] that loads pages of [SourceStatusLog] items.
+     */
+    @Query("SELECT * FROM source_status_log WHERE plugin = :pluginName ORDER BY time ASC")
+    abstract fun pagingSourceByPluginName(pluginName: String): PagingSource<Long, SourceStatusLog>
+
+    /**
+     * Deletes source status log records that have a [SourceStatusLog.time] value between the specified [from] and [to] timestamps.
+     *
+     * @param from the start timestamp (inclusive) for deletion.
+     * @param to the end timestamp (inclusive) for deletion.
+     */
+    @Query("DELETE FROM source_status_log WHERE time BETWEEN :from AND :to")
+    abstract suspend fun deleteStatusesBetweenTimestamps(from: Long, to: Long)
+
+    /**
+     * Deletes the source status log record with the specified [id].
+     *
+     * @param id the unique identifier of the status log to delete.
+     */
+    @Query("DELETE FROM source_status_log WHERE id = :id")
+    abstract suspend fun deleteStatusById(id: Long)
+
+    /**
+     * Deletes the oldest source status log records to ensure that the total number of records does not exceed [count].
+     *
+     * Calculates the number of records that exceed the retention count and then deletes that many
+     * oldest records based on the [SourceStatusLog.time].
+     *
+     * For example: if there are 100 records and [count] is set to 80, then the 20 oldest records (based on [SourceStatusLog.time])
+     * will be deleted.
+     *
+     * @param count the maximum number of recent records to retain.
+     */
+    @Query(
+        """
+    DELETE FROM source_status_log 
+    WHERE id IN (
+        SELECT id FROM source_status_log 
+        ORDER BY time ASC 
+        LIMIT (SELECT COUNT(*) - :count FROM source_status_log)
+    )
+"""
+    )
+    abstract suspend fun deleteStatusesCountGreaterThan(count: Long)
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/SourceStatusDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/SourceStatusDao.kt
@@ -78,9 +78,9 @@ abstract class SourceStatusDao : BaseDao<SourceStatusLog> {
     abstract fun pagingSourceByPluginName(pluginName: String): PagingSource<Long, SourceStatusLog>
 
     /**
-     * Retrieves the total number of status logs present in the [source_status_log] table.
+     * Retrieves the total number of source status logs.
      *
-     * @return the count of status logs.
+     * @return the count of source status.
      */
     @Query("SELECT COUNT(*) FROM source_status_log")
     abstract suspend fun getStatusesCount(): Int
@@ -112,6 +112,8 @@ abstract class SourceStatusDao : BaseDao<SourceStatusLog> {
      * will be deleted.
      *
      * @param count the maximum number of recent records to retain.
+     * @return the number of rows that were deleted.
+     *
      */
     @Query(
         """
@@ -123,5 +125,21 @@ abstract class SourceStatusDao : BaseDao<SourceStatusLog> {
     )
 """
     )
-    abstract suspend fun deleteStatusesCountGreaterThan(count: Long)
+    abstract suspend fun deleteStatusesCountGreaterThan(count: Long): Int
+
+    /**
+     * Deletes source status logs that are older than the specified [time] threshold.
+     *
+     * Useful for removing records that are older than a certain retention period.
+     *
+     * @param time the timestamp threshold. All network status logs with a `time` less than this value will be deleted.
+     * @return the number of rows that were deleted.
+     */
+    @Query(
+        """
+    DELETE FROM source_status_log WHERE time < :time
+    """
+    )
+    abstract suspend fun deleteSourceLogsOlderThan(time: Long): Int
+
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/SourceStatusDao.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/dao/SourceStatusDao.kt
@@ -75,7 +75,7 @@ abstract class SourceStatusDao : BaseDao<SourceStatusLog> {
      * @return a [PagingSource] that loads pages of [SourceStatusLog] items.
      */
     @Query("SELECT * FROM source_status_log WHERE plugin = :pluginName ORDER BY time ASC")
-    abstract fun pagingSourceByPluginName(pluginName: String): PagingSource<Long, SourceStatusLog>
+    abstract fun pagingSourceByPluginName(pluginName: String): PagingSource<Int, SourceStatusLog>
 
     /**
      * Retrieves the total number of source status logs.

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/db/RadarApplicationDatabase.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/db/RadarApplicationDatabase.kt
@@ -1,0 +1,81 @@
+package org.radarbase.android.storage.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import org.radarbase.android.storage.converter.Converters
+import org.radarbase.android.storage.dao.NetworkStatusDao
+import org.radarbase.android.storage.dao.SourceStatusDao
+import org.radarbase.android.storage.entity.NetworkStatusLog
+import org.radarbase.android.storage.entity.SourceStatusLog
+
+/**
+ * Database for the Radar Application.
+ *
+ * This database manages two entities:
+ * - [SourceStatusLog]: Logs related to source status.
+ * - [NetworkStatusLog]: Logs related to network connection status.
+ *
+ * Access to these entities is provided via the [sourceStatusDao] and [networkStatusDao] methods.
+ *
+ * ## Migrations
+ *
+ * The database currently uses destructive migration ([RoomDatabase::fallbackToDestructiveMigration]).
+ * For version 1 this is acceptable, but in the future proper migration paths should be defined
+ * to preserve user data. Automated migrations are supported when [Database.exportSchema] is set to true.
+ *
+ * @see <a href="https://developer.android.com/training/data-storage/room/migrating-db-versions">Migrating Room Databases</a>
+ */
+@Database(
+    version = 1,
+    entities = [SourceStatusLog::class, NetworkStatusLog::class],
+    exportSchema = true
+)
+@TypeConverters(Converters::class)
+@Suppress("unused")
+abstract class RadarApplicationDatabase : RoomDatabase() {
+
+    /**
+     * Provides access to the DAO for source status log operations.
+     *
+     * @return an instance of [SourceStatusDao].
+     */
+    abstract fun sourceStatusDao(): SourceStatusDao
+
+    /**
+     * Provides access to the DAO for network status log operations.
+     *
+     * @return an instance of [NetworkStatusDao].
+     */
+    abstract fun networkStatusDao(): NetworkStatusDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: RadarApplicationDatabase? = null
+
+        /**
+         * Retrieves the singleton instance of [RadarApplicationDatabase].
+         *
+         * The database is built using a destructive migration strategy ([RoomDatabase::fallbackToDestructiveMigration]).
+         * In the future, migration paths can be added with [RoomDatabase::addMigrations] to preserve user data.
+         *
+         * @param context the application context.
+         * @return the singleton instance of [RadarApplicationDatabase].
+         */
+        fun getInstance(context: Context): RadarApplicationDatabase {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    RadarApplicationDatabase::class.java,
+                    "radar_app_db"
+                )
+                    // Using fallbackToDestructiveMigration() for now since this is version 1.
+                    // In the future, add proper migration paths using .addMigrations(MIGRATION_1_2, ...)
+                    .fallbackToDestructiveMigration()
+                    .build().also { INSTANCE = it }
+            }
+        }
+    }
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/ConnectionStatus.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/ConnectionStatus.kt
@@ -1,5 +1,5 @@
 package org.radarbase.android.storage.entity
 
-enum class NetworkStatus {
+enum class ConnectionStatus {
     DISCONNECTED, CONNECTED_WIFI, CONNECTED_CELLULAR
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatus.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatus.kt
@@ -1,0 +1,5 @@
+package org.radarbase.android.storage.entity
+
+enum class NetworkStatus {
+    DISCONNECTED, CONNECTED_WIFI, CONNECTED_CELLULAR
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatusLog.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatusLog.kt
@@ -10,7 +10,7 @@ import androidx.room.PrimaryKey
     indices = [Index(value = ["time"])]
 )
 data class NetworkStatusLog(
-    @PrimaryKey(autoGenerate = true) val id: Long,
+    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
     val time: Long,
     @ColumnInfo("connection_state") val connectionStatus: ConnectionStatus
 )

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatusLog.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatusLog.kt
@@ -12,5 +12,5 @@ import androidx.room.PrimaryKey
 data class NetworkStatusLog(
     @PrimaryKey(autoGenerate = true) val id: Long,
     val time: Long,
-    @ColumnInfo("connection_state") val connectionState: NetworkStatus
+    @ColumnInfo("connection_state") val connectionStatus: ConnectionStatus
 )

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatusLog.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatusLog.kt
@@ -10,7 +10,7 @@ import androidx.room.PrimaryKey
     indices = [Index(value = ["time"])]
 )
 data class NetworkStatusLog(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val time: Long,
     @ColumnInfo("connection_state") val connectionStatus: ConnectionStatus
 )

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatusLog.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/NetworkStatusLog.kt
@@ -1,0 +1,16 @@
+package org.radarbase.android.storage.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "network_status_log",
+    indices = [Index(value = ["time"])]
+)
+data class NetworkStatusLog(
+    @PrimaryKey(autoGenerate = true) val id: Long,
+    val time: Long,
+    @ColumnInfo("connection_state") val connectionState: NetworkStatus
+)

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/SourceStatusLog.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/SourceStatusLog.kt
@@ -1,0 +1,21 @@
+package org.radarbase.android.storage.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import org.radarbase.android.source.SourceStatusListener
+
+@Entity(
+    tableName = "source_status_log",
+    indices = [
+        Index(value = ["time"]),
+        Index(value = ["plugin"])
+    ]
+)
+data class SourceStatusLog(
+    @PrimaryKey(autoGenerate = true) val id: Long,
+    val time: Long,
+    val plugin: String,
+    @ColumnInfo("source_status") val sourceStatus: SourceStatusListener.Status
+)

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/SourceStatusLog.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/SourceStatusLog.kt
@@ -14,7 +14,7 @@ import org.radarbase.android.source.SourceStatusListener
     ]
 )
 data class SourceStatusLog(
-    @PrimaryKey(autoGenerate = true) val id: Long,
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val time: Long,
     val plugin: String,
     @ColumnInfo("source_status") val sourceStatus: SourceStatusListener.Status

--- a/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/SourceStatusLog.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/storage/entity/SourceStatusLog.kt
@@ -14,7 +14,7 @@ import org.radarbase.android.source.SourceStatusListener
     ]
 )
 data class SourceStatusLog(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val time: Long,
     val plugin: String,
     @ColumnInfo("source_status") val sourceStatus: SourceStatusListener.Status

--- a/radar-commons-android/src/main/res/schemas/org.radarbase.android.storage.db.RadarApplicationDatabase/1.json
+++ b/radar-commons-android/src/main/res/schemas/org.radarbase.android.storage.db.RadarApplicationDatabase/1.json
@@ -1,0 +1,113 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "589f075432cf059d2896c60f08304494",
+    "entities": [
+      {
+        "tableName": "source_status_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `time` INTEGER NOT NULL, `plugin` TEXT NOT NULL, `source_status` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plugin",
+            "columnName": "plugin",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceStatus",
+            "columnName": "source_status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_source_status_log_time",
+            "unique": false,
+            "columnNames": [
+              "time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_source_status_log_time` ON `${TABLE_NAME}` (`time`)"
+          },
+          {
+            "name": "index_source_status_log_plugin",
+            "unique": false,
+            "columnNames": [
+              "plugin"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_source_status_log_plugin` ON `${TABLE_NAME}` (`plugin`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "network_status_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `time` INTEGER NOT NULL, `connection_state` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectionState",
+            "columnName": "connection_state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_network_status_log_time",
+            "unique": false,
+            "columnNames": [
+              "time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_network_status_log_time` ON `${TABLE_NAME}` (`time`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '589f075432cf059d2896c60f08304494')"
+    ]
+  }
+}


### PR DESCRIPTION
### Application Metrics Collection and Storage
Three new topics have been introduced for collecting application metrics:

**1. Plugin Status** – Tracks the status of each plugin.
**2. Application Network Connectivity** – Monitors the application's network connectivity status.
**3. Records Sent per Topic** – Measures the number of records sent per topic.

Only the "number of records sent per topic" is collected in the background. However, the plugin status and network status are reported only when application metrics are explicitly initiated by the user.

The data for these two topics is stored in the database. To support this, Room Database has been integrated into the application. Room is a wrapper over SQLite for Android, offering robust database access and compile-time query verification, making it preferable over direct SQL usage.

The stored data is retained for a specific duration and has a defined limit. When either the retention time or storage limit is exceeded, the database is automatically cleared.

### Summary of Application Metrics Storage Policies
* Defines the interval for verifying that records older than application_metrics_retention_time are not present. 
* Specifies the number of records to retain in the buffer before adding them to the database. Batching records is done to improve performance.
* Determines the retention period for application metrics. Older records are automatically deleted.
* Sets a maximum limit on stored messages. When this limit is exceeded, older messages are removed.

